### PR TITLE
Add TH-based RJ45 with no shifter needed

### DIFF
--- a/docs/PCB Information.md
+++ b/docs/PCB Information.md
@@ -132,11 +132,32 @@ Eagle Files:
 
 ##### Bill of Materials:
 
-1x [2-Pin 5mm Pitch Screw Terminal](https://www.aliexpress.com/item/100PCS-2-Pin-Screw-Terminal-Block-Connector-5mm-Pitch-Free-Shipping/32700056337.html)  
-2x [4-Pin 5mm Pitch Screw Terminal](https://www.aliexpress.com/item/100-pcs-4-Pin-Screw-blue-PCB-Terminal-Block-Connector-5mm-Pitch/32658656423.html) (Alternatively, 4x 2-pin terminals)  
-1x [2-Pin Pin Header](https://www.aliexpress.com/item/Free-Shipping-40-Pins-Header-Strip-Socket-2-54mm-Straight-Single-Row-Pin-Male-For-Arduino/2046893919.html)  
-1x [10k 1/4 Watt Axial Resistor](https://www.aliexpress.com/item/100pcs-10k-ohm-1-4W-10k-Metal-Film-Resistor-10kohm-0-25W-1-ROHS/32577051768.html)  
-1x [Sparkfun (or compatible) Level Shifter](https://www.aliexpress.com/item/1pcs-Logic-Level-Shifter-Bi-Directional-For-Arduino-Four-Way-Ttwo-Way-Logic-Level-Transformation-Module/32624272876.html)  
-1x [RJ-11 Jack](https://www.aliexpress.com/item/RJ11-socket-outlet-90-degree-6-core-crystal-head-95001-6P6C-black-base-HXDD2/32685158354.html)  
-1x [WeMos D1 Mini ESP8266 board](https://wiki.wemos.cc/products:d1:d1_mini)  
-1x [LCD 20x4 I2C LCD Screen](https://www.aliexpress.com/item/Free-shipping-LCD-module-Blue-screen-IIC-I2C-2004-5V-20X4-LCD-board-provides-library-files/1873368596.html)
+1 x [2-Pin 5mm Pitch Screw Terminal](https://www.aliexpress.com/item/100PCS-2-Pin-Screw-Terminal-Block-Connector-5mm-Pitch-Free-Shipping/32700056337.html)  
+2 x [4-Pin 5mm Pitch Screw Terminal](https://www.aliexpress.com/item/100-pcs-4-Pin-Screw-blue-PCB-Terminal-Block-Connector-5mm-Pitch/32658656423.html) (Alternatively, 4x 2-pin terminals)  
+1 x [2-Pin Pin Header](https://www.aliexpress.com/item/Free-Shipping-40-Pins-Header-Strip-Socket-2-54mm-Straight-Single-Row-Pin-Male-For-Arduino/2046893919.html)  
+1 x [10k 1/4 Watt Axial Resistor](https://www.aliexpress.com/item/100pcs-10k-ohm-1-4W-10k-Metal-Film-Resistor-10kohm-0-25W-1-ROHS/32577051768.html)  
+1 x [Sparkfun (or compatible) Level Shifter](https://www.aliexpress.com/item/1pcs-Logic-Level-Shifter-Bi-Directional-For-Arduino-Four-Way-Ttwo-Way-Logic-Level-Transformation-Module/32624272876.html)  
+1 x [RJ-11 Jack](https://www.aliexpress.com/item/RJ11-socket-outlet-90-degree-6-core-crystal-head-95001-6P6C-black-base-HXDD2/32685158354.html)  
+1 x [WeMos D1 Mini ESP8266 board](https://wiki.wemos.cc/products:d1:d1_mini)  
+1 x [LCD 20x4 I2C LCD Screen](https://www.aliexpress.com/item/Free-shipping-LCD-module-Blue-screen-IIC-I2C-2004-5V-20X4-LCD-board-provides-library-files/1873368596.html)
+
+### LCD Support with DuPont connectors and through-hole components (no SparkFun level converter sub-board needed)
+
+Purchase Boards (coming soon)  
+
+Eagle Files:
+
+*   D1 Breakout - LCD TH Dupont RJ45 Logo.brd (coming soon)
+*   D1 Breakout - LCD TH Dupont RJ45 Logo.brd (coming soon)
+
+##### Bill of Materials:
+
+- 1x [2-Pin 5mm Pitch Screw Terminal](https://www.aliexpress.com/item/100PCS-2-Pin-Screw-Terminal-Block-Connector-5mm-Pitch-Free-Shipping/32700056337.html)  
+- 1x [2-Pin Pin Header](https://www.aliexpress.com/item/Free-Shipping-40-Pins-Header-Strip-Socket-2-54mm-Straight-Single-Row-Pin-Male-For-Arduino/2046893919.html)  
+- 2x [4-Pin Pin Header](https://www.aliexpress.com/item/Free-Shipping-40-Pins-Header-Strip-Socket-2-54mm-Straight-Single-Row-Pin-Male-For-Arduino/2046893919.html)  
+- 5x [10k 1/4 Watt Axial Resistor](https://www.aliexpress.com/item/100pcs-10k-ohm-1-4W-10k-Metal-Film-Resistor-10kohm-0-25W-1-ROHS/32577051768.html)  
+- 1x [RJ-45 Jack](https://www.aliexpress.com/item/High-Quality-20pcs-RJ45-8P8C-Computer-Internet-Network-PCB-Jack-Socket-Black/32736146888.html)
+- 2x [2N7000 MOSFET](https://www.aliexpress.com/item/32993994244.html)
+1x [100uF ceramic Capacitor](https://www.mouser.com/ProductDetail/United-Chemi-Con/KTD250B107M80A0B00?qs=YQnJFR48xcDR2vQIc5p%2FHg%3D%3D) (optional)
+- 1x [WeMos D1 Mini ESP8266 board](https://wiki.wemos.cc/products:d1:d1_mini)  
+- 1x [LCD 20x4 I2C LCD Screen](https://www.aliexpress.com/item/Free-shipping-LCD-module-Blue-screen-IIC-I2C-2004-5V-20X4-LCD-board-provides-library-files/1873368596.html)

--- a/hardware/D1 Breakout - LCD TH Dupont RJ45 Logo.brd
+++ b/hardware/D1 Breakout - LCD TH Dupont RJ45 Logo.brd
@@ -1,0 +1,2896 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE eagle SYSTEM "eagle.dtd">
+<eagle version="9.4.2">
+<drawing>
+<settings>
+<setting alwaysvectorfont="yes"/>
+<setting keepoldvectorfont="yes"/>
+<setting verticaltext="up"/>
+</settings>
+<grid distance="0.1" unitdist="mm" unit="mm" style="lines" multiple="1" display="yes" altdistance="0.01" altunitdist="mm" altunit="mm"/>
+<layers>
+<layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
+<layer number="2" name="Route2" color="1" fill="3" visible="yes" active="yes"/>
+<layer number="3" name="Route3" color="4" fill="3" visible="yes" active="yes"/>
+<layer number="4" name="Route4" color="1" fill="4" visible="yes" active="yes"/>
+<layer number="5" name="Route5" color="4" fill="4" visible="yes" active="yes"/>
+<layer number="6" name="Route6" color="1" fill="8" visible="yes" active="yes"/>
+<layer number="7" name="Route7" color="4" fill="8" visible="yes" active="yes"/>
+<layer number="8" name="Route8" color="1" fill="2" visible="yes" active="yes"/>
+<layer number="9" name="Route9" color="4" fill="2" visible="yes" active="yes"/>
+<layer number="10" name="Route10" color="1" fill="7" visible="yes" active="yes"/>
+<layer number="11" name="Route11" color="4" fill="7" visible="yes" active="yes"/>
+<layer number="12" name="Route12" color="1" fill="5" visible="yes" active="yes"/>
+<layer number="13" name="Route13" color="4" fill="5" visible="yes" active="yes"/>
+<layer number="14" name="Route14" color="1" fill="6" visible="yes" active="yes"/>
+<layer number="15" name="Route15" color="4" fill="6" visible="yes" active="yes"/>
+<layer number="16" name="Bottom" color="1" fill="1" visible="yes" active="yes"/>
+<layer number="17" name="Pads" color="2" fill="1" visible="yes" active="yes"/>
+<layer number="18" name="Vias" color="2" fill="1" visible="yes" active="yes"/>
+<layer number="19" name="Unrouted" color="6" fill="1" visible="yes" active="yes"/>
+<layer number="20" name="Dimension" color="15" fill="1" visible="yes" active="yes"/>
+<layer number="21" name="tPlace" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="22" name="bPlace" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="23" name="tOrigins" color="15" fill="1" visible="yes" active="yes"/>
+<layer number="24" name="bOrigins" color="15" fill="1" visible="yes" active="yes"/>
+<layer number="25" name="tNames" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="26" name="bNames" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="27" name="tValues" color="7" fill="1" visible="no" active="yes"/>
+<layer number="28" name="bValues" color="7" fill="1" visible="no" active="yes"/>
+<layer number="29" name="tStop" color="7" fill="3" visible="no" active="yes"/>
+<layer number="30" name="bStop" color="7" fill="6" visible="no" active="yes"/>
+<layer number="31" name="tCream" color="7" fill="4" visible="no" active="yes"/>
+<layer number="32" name="bCream" color="7" fill="5" visible="no" active="yes"/>
+<layer number="33" name="tFinish" color="6" fill="3" visible="no" active="yes"/>
+<layer number="34" name="bFinish" color="6" fill="6" visible="no" active="yes"/>
+<layer number="35" name="tGlue" color="7" fill="4" visible="no" active="yes"/>
+<layer number="36" name="bGlue" color="7" fill="5" visible="no" active="yes"/>
+<layer number="37" name="tTest" color="7" fill="1" visible="no" active="yes"/>
+<layer number="38" name="bTest" color="7" fill="1" visible="no" active="yes"/>
+<layer number="39" name="tKeepout" color="4" fill="11" visible="yes" active="yes"/>
+<layer number="40" name="bKeepout" color="1" fill="11" visible="yes" active="yes"/>
+<layer number="41" name="tRestrict" color="4" fill="10" visible="yes" active="yes"/>
+<layer number="42" name="bRestrict" color="1" fill="10" visible="yes" active="yes"/>
+<layer number="43" name="vRestrict" color="2" fill="10" visible="no" active="yes"/>
+<layer number="44" name="Drills" color="7" fill="1" visible="no" active="yes"/>
+<layer number="45" name="Holes" color="7" fill="1" visible="no" active="yes"/>
+<layer number="46" name="Milling" color="3" fill="1" visible="no" active="yes"/>
+<layer number="47" name="Measures" color="7" fill="1" visible="no" active="yes"/>
+<layer number="48" name="Document" color="7" fill="1" visible="no" active="yes"/>
+<layer number="49" name="Reference" color="7" fill="1" visible="no" active="yes"/>
+<layer number="50" name="dxf" color="7" fill="1" visible="no" active="no"/>
+<layer number="51" name="tDocu" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="52" name="bDocu" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="53" name="tGND_GNDA" color="7" fill="9" visible="no" active="no"/>
+<layer number="54" name="bGND_GNDA" color="1" fill="9" visible="no" active="no"/>
+<layer number="56" name="wert" color="7" fill="1" visible="no" active="no"/>
+<layer number="57" name="tCAD" color="7" fill="1" visible="no" active="no"/>
+<layer number="59" name="tCarbon" color="7" fill="1" visible="no" active="no"/>
+<layer number="60" name="bCarbon" color="7" fill="1" visible="no" active="no"/>
+<layer number="90" name="Modules" color="5" fill="1" visible="no" active="no"/>
+<layer number="91" name="Nets" color="2" fill="1" visible="no" active="no"/>
+<layer number="92" name="Busses" color="1" fill="1" visible="no" active="no"/>
+<layer number="93" name="Pins" color="2" fill="1" visible="no" active="no"/>
+<layer number="94" name="Symbols" color="4" fill="1" visible="no" active="no"/>
+<layer number="95" name="Names" color="7" fill="1" visible="no" active="no"/>
+<layer number="96" name="Values" color="7" fill="1" visible="no" active="no"/>
+<layer number="97" name="Info" color="7" fill="1" visible="no" active="no"/>
+<layer number="98" name="Guide" color="6" fill="1" visible="no" active="no"/>
+<layer number="99" name="SpiceOrder" color="5" fill="1" visible="no" active="no"/>
+<layer number="100" name="Muster" color="7" fill="1" visible="no" active="no"/>
+<layer number="101" name="Patch_Top" color="12" fill="4" visible="no" active="yes"/>
+<layer number="102" name="Vscore" color="7" fill="1" visible="no" active="yes"/>
+<layer number="103" name="tMap" color="7" fill="1" visible="no" active="yes"/>
+<layer number="104" name="Name" color="16" fill="1" visible="no" active="yes"/>
+<layer number="105" name="tPlate" color="7" fill="1" visible="no" active="yes"/>
+<layer number="106" name="bPlate" color="7" fill="1" visible="no" active="yes"/>
+<layer number="107" name="Crop" color="7" fill="1" visible="no" active="yes"/>
+<layer number="108" name="tplace-old" color="10" fill="1" visible="no" active="yes"/>
+<layer number="109" name="ref-old" color="11" fill="1" visible="no" active="yes"/>
+<layer number="110" name="fp0" color="7" fill="1" visible="no" active="yes"/>
+<layer number="111" name="LPC17xx" color="7" fill="1" visible="no" active="yes"/>
+<layer number="112" name="tSilk" color="7" fill="1" visible="no" active="yes"/>
+<layer number="113" name="IDFDebug" color="7" fill="1" visible="no" active="yes"/>
+<layer number="114" name="Badge_Outline" color="11" fill="1" visible="no" active="no"/>
+<layer number="115" name="ReferenceISLANDS" color="7" fill="1" visible="no" active="yes"/>
+<layer number="116" name="Patch_BOT" color="9" fill="4" visible="no" active="yes"/>
+<layer number="118" name="Rect_Pads" color="7" fill="1" visible="no" active="yes"/>
+<layer number="121" name="_tsilk" color="7" fill="1" visible="no" active="yes"/>
+<layer number="122" name="_bsilk" color="7" fill="1" visible="no" active="yes"/>
+<layer number="123" name="tTestmark" color="7" fill="1" visible="no" active="yes"/>
+<layer number="124" name="bTestmark" color="7" fill="1" visible="no" active="yes"/>
+<layer number="125" name="_tNames" color="7" fill="1" visible="no" active="yes"/>
+<layer number="126" name="_bNames" color="7" fill="1" visible="no" active="yes"/>
+<layer number="127" name="_tValues" color="7" fill="1" visible="no" active="yes"/>
+<layer number="128" name="_bValues" color="7" fill="1" visible="no" active="yes"/>
+<layer number="129" name="Mask" color="7" fill="1" visible="no" active="yes"/>
+<layer number="131" name="tAdjust" color="7" fill="1" visible="no" active="yes"/>
+<layer number="132" name="bAdjust" color="7" fill="1" visible="no" active="yes"/>
+<layer number="144" name="Drill_legend" color="7" fill="1" visible="no" active="yes"/>
+<layer number="150" name="Notes" color="7" fill="1" visible="no" active="yes"/>
+<layer number="151" name="HeatSink" color="7" fill="1" visible="no" active="yes"/>
+<layer number="152" name="_bDocu" color="7" fill="1" visible="no" active="yes"/>
+<layer number="153" name="FabDoc1" color="7" fill="1" visible="no" active="yes"/>
+<layer number="154" name="FabDoc2" color="7" fill="1" visible="no" active="yes"/>
+<layer number="155" name="FabDoc3" color="7" fill="1" visible="no" active="yes"/>
+<layer number="199" name="Contour" color="7" fill="1" visible="no" active="yes"/>
+<layer number="200" name="200bmp" color="1" fill="10" visible="no" active="yes"/>
+<layer number="201" name="201bmp" color="2" fill="10" visible="no" active="yes"/>
+<layer number="202" name="202bmp" color="3" fill="10" visible="no" active="yes"/>
+<layer number="203" name="203bmp" color="4" fill="10" visible="no" active="yes"/>
+<layer number="204" name="204bmp" color="5" fill="10" visible="no" active="yes"/>
+<layer number="205" name="205bmp" color="6" fill="10" visible="no" active="yes"/>
+<layer number="206" name="206bmp" color="7" fill="10" visible="no" active="yes"/>
+<layer number="207" name="207bmp" color="8" fill="10" visible="no" active="yes"/>
+<layer number="208" name="208bmp" color="9" fill="10" visible="no" active="yes"/>
+<layer number="209" name="209bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="210" name="210bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="211" name="211bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="212" name="212bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="213" name="213bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="214" name="214bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="215" name="215bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="216" name="216bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="217" name="217bmp" color="18" fill="1" visible="no" active="no"/>
+<layer number="218" name="218bmp" color="19" fill="1" visible="no" active="no"/>
+<layer number="219" name="219bmp" color="20" fill="1" visible="no" active="no"/>
+<layer number="220" name="220bmp" color="21" fill="1" visible="no" active="no"/>
+<layer number="221" name="221bmp" color="22" fill="1" visible="no" active="no"/>
+<layer number="222" name="222bmp" color="23" fill="1" visible="no" active="no"/>
+<layer number="223" name="223bmp" color="24" fill="1" visible="no" active="no"/>
+<layer number="224" name="224bmp" color="25" fill="1" visible="no" active="no"/>
+<layer number="225" name="225bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="226" name="226bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="227" name="227bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="228" name="228bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="229" name="229bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="230" name="230bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="231" name="231bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="248" name="Housing" color="7" fill="1" visible="no" active="yes"/>
+<layer number="249" name="Edge" color="7" fill="1" visible="no" active="yes"/>
+<layer number="250" name="Descript" color="3" fill="1" visible="no" active="no"/>
+<layer number="251" name="SMDround" color="12" fill="11" visible="no" active="no"/>
+<layer number="254" name="cooling" color="7" fill="1" visible="no" active="yes"/>
+<layer number="255" name="routoute" color="7" fill="1" visible="no" active="yes"/>
+</layers>
+<board>
+<plain>
+<wire x1="40.005" y1="31.115" x2="40.64" y2="30.48" width="0" layer="20"/>
+<wire x1="40.64" y1="30.48" x2="83.49" y2="30.48" width="0" layer="20"/>
+<wire x1="83.49" y1="30.48" x2="83.49" y2="73.015" width="0" layer="20"/>
+<wire x1="83.49" y1="73.015" x2="82.55" y2="74.285" width="0" layer="20"/>
+<wire x1="82.55" y1="74.285" x2="81.28" y2="74.295" width="0" layer="20"/>
+<wire x1="81.28" y1="74.295" x2="41.275" y2="74.295" width="0" layer="20"/>
+<wire x1="41.275" y1="74.295" x2="40.005" y2="73.015" width="0" layer="20"/>
+<wire x1="40.005" y1="73.015" x2="40.005" y2="31.115" width="0" layer="20"/>
+<text x="49.935" y="46.72" size="0.8128" layer="21" ratio="1" rot="R90">HEAT</text>
+<text x="47.425" y="46.72" size="0.8128" layer="21" ratio="1" rot="R90">COOL</text>
+<text x="44.815" y="47.468415625" size="0.8128" layer="21" ratio="1" rot="R90">GND</text>
+<text x="83.115" y="71.48" size="0.8128" layer="21" ratio="1" align="bottom-right">5V</text>
+<text x="70.65" y="71.48" size="0.8128" layer="21" ratio="1" align="bottom-right">GND</text>
+<text x="82.08" y="64.92" size="0.8128" layer="26" ratio="1" rot="MR0">BrewPi D1 Mini RJ45 TH
+Breakout Board v1.0
+@LBussy on HBT</text>
+<text x="44.885" y="56.245" size="0.8128" layer="21" ratio="1" rot="R90">GND</text>
+<text x="52.575" y="47.468415625" size="0.8128" layer="21" ratio="1" rot="R90">+5V</text>
+<text x="47.525" y="56.245" size="0.8128" layer="21" ratio="1" rot="R90">+5V</text>
+<text x="49.965" y="56.245" size="0.8128" layer="21" ratio="1" rot="R90">SDA</text>
+<text x="52.505" y="56.245" size="0.8128" layer="21" ratio="1" rot="R90">SCL</text>
+<text x="77.765" y="54.775" size="0.8128" layer="26" ratio="1" rot="MR0">D0 - Heat 
+D1 - I2C SCL 
+D2 - I2C SDA 
+D3 - Buzzer
+D5 - Cool 
+D6 - OneWire Data 
+D7 - Door</text>
+<rectangle x1="52.62825" y1="67.41795" x2="52.92035" y2="67.43065" layer="21"/>
+<rectangle x1="52.47585" y1="67.43065" x2="53.07275" y2="67.44335" layer="21"/>
+<rectangle x1="52.37425" y1="67.44335" x2="53.17435" y2="67.45605" layer="21"/>
+<rectangle x1="52.28535" y1="67.45605" x2="53.26325" y2="67.46875" layer="21"/>
+<rectangle x1="52.24725" y1="67.46875" x2="53.31405" y2="67.48145" layer="21"/>
+<rectangle x1="52.18375" y1="67.48145" x2="53.37755" y2="67.49415" layer="21"/>
+<rectangle x1="52.13295" y1="67.49415" x2="53.42835" y2="67.50685" layer="21"/>
+<rectangle x1="52.08215" y1="67.50685" x2="53.49185" y2="67.51955" layer="21"/>
+<rectangle x1="52.03135" y1="67.51955" x2="53.52995" y2="67.53225" layer="21"/>
+<rectangle x1="51.99325" y1="67.53225" x2="53.56805" y2="67.54495" layer="21"/>
+<rectangle x1="51.95515" y1="67.54495" x2="53.61885" y2="67.55765" layer="21"/>
+<rectangle x1="51.91705" y1="67.55765" x2="53.65695" y2="67.57035" layer="21"/>
+<rectangle x1="51.89165" y1="67.57035" x2="53.68235" y2="67.58305" layer="21"/>
+<rectangle x1="51.85355" y1="67.58305" x2="53.72045" y2="67.59575" layer="21"/>
+<rectangle x1="51.81545" y1="67.59575" x2="53.75855" y2="67.60845" layer="21"/>
+<rectangle x1="51.79005" y1="67.60845" x2="53.79665" y2="67.62115" layer="21"/>
+<rectangle x1="51.76465" y1="67.62115" x2="53.82205" y2="67.63385" layer="21"/>
+<rectangle x1="51.72655" y1="67.63385" x2="53.86015" y2="67.64655" layer="21"/>
+<rectangle x1="51.70115" y1="67.64655" x2="52.57745" y2="67.65925" layer="21"/>
+<rectangle x1="52.94575" y1="67.64655" x2="53.88555" y2="67.65925" layer="21"/>
+<rectangle x1="51.67575" y1="67.65925" x2="52.45045" y2="67.67195" layer="21"/>
+<rectangle x1="53.07275" y1="67.65925" x2="53.92365" y2="67.67195" layer="21"/>
+<rectangle x1="51.63765" y1="67.67195" x2="52.37425" y2="67.68465" layer="21"/>
+<rectangle x1="53.17435" y1="67.67195" x2="53.94905" y2="67.68465" layer="21"/>
+<rectangle x1="51.62495" y1="67.68465" x2="52.37425" y2="67.69735" layer="21"/>
+<rectangle x1="53.22515" y1="67.68465" x2="53.97445" y2="67.69735" layer="21"/>
+<rectangle x1="51.58685" y1="67.69735" x2="52.41235" y2="67.71005" layer="21"/>
+<rectangle x1="53.28865" y1="67.69735" x2="53.99985" y2="67.71005" layer="21"/>
+<rectangle x1="51.56145" y1="67.71005" x2="52.42505" y2="67.72275" layer="21"/>
+<rectangle x1="53.35215" y1="67.71005" x2="54.02525" y2="67.72275" layer="21"/>
+<rectangle x1="51.54875" y1="67.72275" x2="51.84085" y2="67.73545" layer="21"/>
+<rectangle x1="52.04405" y1="67.72275" x2="52.43775" y2="67.73545" layer="21"/>
+<rectangle x1="53.39025" y1="67.72275" x2="54.03795" y2="67.73545" layer="21"/>
+<rectangle x1="51.52335" y1="67.73545" x2="51.77735" y2="67.74815" layer="21"/>
+<rectangle x1="52.12025" y1="67.73545" x2="52.46315" y2="67.74815" layer="21"/>
+<rectangle x1="53.44105" y1="67.73545" x2="54.06335" y2="67.74815" layer="21"/>
+<rectangle x1="51.49795" y1="67.74815" x2="51.73925" y2="67.76085" layer="21"/>
+<rectangle x1="52.17105" y1="67.74815" x2="52.47585" y2="67.76085" layer="21"/>
+<rectangle x1="53.49185" y1="67.74815" x2="54.08875" y2="67.76085" layer="21"/>
+<rectangle x1="51.48525" y1="67.76085" x2="51.71385" y2="67.77355" layer="21"/>
+<rectangle x1="52.19645" y1="67.76085" x2="52.48855" y2="67.77355" layer="21"/>
+<rectangle x1="53.51725" y1="67.76085" x2="54.11415" y2="67.77355" layer="21"/>
+<rectangle x1="51.45985" y1="67.77355" x2="51.68845" y2="67.78625" layer="21"/>
+<rectangle x1="52.23455" y1="67.77355" x2="52.51395" y2="67.78625" layer="21"/>
+<rectangle x1="53.56805" y1="67.77355" x2="54.12685" y2="67.78625" layer="21"/>
+<rectangle x1="51.43445" y1="67.78625" x2="51.66305" y2="67.79895" layer="21"/>
+<rectangle x1="52.27265" y1="67.78625" x2="52.52665" y2="67.79895" layer="21"/>
+<rectangle x1="53.60615" y1="67.78625" x2="54.15225" y2="67.79895" layer="21"/>
+<rectangle x1="51.40905" y1="67.79895" x2="51.63765" y2="67.81165" layer="21"/>
+<rectangle x1="52.29805" y1="67.79895" x2="52.53935" y2="67.81165" layer="21"/>
+<rectangle x1="53.65695" y1="67.79895" x2="54.17765" y2="67.81165" layer="21"/>
+<rectangle x1="51.38365" y1="67.81165" x2="51.62495" y2="67.82435" layer="21"/>
+<rectangle x1="52.32345" y1="67.81165" x2="52.56475" y2="67.82435" layer="21"/>
+<rectangle x1="53.68235" y1="67.81165" x2="54.19035" y2="67.82435" layer="21"/>
+<rectangle x1="51.37095" y1="67.82435" x2="51.61225" y2="67.83705" layer="21"/>
+<rectangle x1="52.33615" y1="67.82435" x2="52.56475" y2="67.83705" layer="21"/>
+<rectangle x1="53.72045" y1="67.82435" x2="54.21575" y2="67.83705" layer="21"/>
+<rectangle x1="51.35825" y1="67.83705" x2="51.59955" y2="67.84975" layer="21"/>
+<rectangle x1="52.36155" y1="67.83705" x2="52.59015" y2="67.84975" layer="21"/>
+<rectangle x1="53.75855" y1="67.83705" x2="54.22845" y2="67.84975" layer="21"/>
+<rectangle x1="51.33285" y1="67.84975" x2="51.58685" y2="67.86245" layer="21"/>
+<rectangle x1="52.37425" y1="67.84975" x2="52.59015" y2="67.86245" layer="21"/>
+<rectangle x1="53.78395" y1="67.84975" x2="54.25385" y2="67.86245" layer="21"/>
+<rectangle x1="51.32015" y1="67.86245" x2="51.57415" y2="67.87515" layer="21"/>
+<rectangle x1="52.39965" y1="67.86245" x2="52.61555" y2="67.87515" layer="21"/>
+<rectangle x1="53.82205" y1="67.86245" x2="54.26655" y2="67.87515" layer="21"/>
+<rectangle x1="51.29475" y1="67.87515" x2="51.56145" y2="67.88785" layer="21"/>
+<rectangle x1="52.41235" y1="67.87515" x2="52.61555" y2="67.88785" layer="21"/>
+<rectangle x1="53.83475" y1="67.87515" x2="54.27925" y2="67.88785" layer="21"/>
+<rectangle x1="51.28205" y1="67.88785" x2="51.54875" y2="67.90055" layer="21"/>
+<rectangle x1="52.42505" y1="67.88785" x2="52.62825" y2="67.90055" layer="21"/>
+<rectangle x1="53.87285" y1="67.88785" x2="54.30465" y2="67.90055" layer="21"/>
+<rectangle x1="51.25665" y1="67.90055" x2="51.53605" y2="67.91325" layer="21"/>
+<rectangle x1="52.43775" y1="67.90055" x2="52.64095" y2="67.91325" layer="21"/>
+<rectangle x1="53.89825" y1="67.90055" x2="54.31735" y2="67.91325" layer="21"/>
+<rectangle x1="51.25665" y1="67.91325" x2="51.53605" y2="67.92595" layer="21"/>
+<rectangle x1="52.46315" y1="67.91325" x2="52.65365" y2="67.92595" layer="21"/>
+<rectangle x1="53.92365" y1="67.91325" x2="54.33005" y2="67.92595" layer="21"/>
+<rectangle x1="51.23125" y1="67.92595" x2="51.52335" y2="67.93865" layer="21"/>
+<rectangle x1="52.47585" y1="67.92595" x2="52.66635" y2="67.93865" layer="21"/>
+<rectangle x1="53.94905" y1="67.92595" x2="54.35545" y2="67.93865" layer="21"/>
+<rectangle x1="51.21855" y1="67.93865" x2="51.52335" y2="67.95135" layer="21"/>
+<rectangle x1="52.48855" y1="67.93865" x2="52.67905" y2="67.95135" layer="21"/>
+<rectangle x1="53.97445" y1="67.93865" x2="54.36815" y2="67.95135" layer="21"/>
+<rectangle x1="51.19315" y1="67.95135" x2="51.51065" y2="67.96405" layer="21"/>
+<rectangle x1="52.50125" y1="67.95135" x2="52.69175" y2="67.96405" layer="21"/>
+<rectangle x1="53.99985" y1="67.95135" x2="54.38085" y2="67.96405" layer="21"/>
+<rectangle x1="51.19315" y1="67.96405" x2="51.51065" y2="67.97675" layer="21"/>
+<rectangle x1="52.50125" y1="67.96405" x2="52.69175" y2="67.97675" layer="21"/>
+<rectangle x1="54.01255" y1="67.96405" x2="54.39355" y2="67.97675" layer="21"/>
+<rectangle x1="51.18045" y1="67.97675" x2="51.49795" y2="67.98945" layer="21"/>
+<rectangle x1="52.52665" y1="67.97675" x2="52.70445" y2="67.98945" layer="21"/>
+<rectangle x1="54.03795" y1="67.97675" x2="54.40625" y2="67.98945" layer="21"/>
+<rectangle x1="51.15505" y1="67.98945" x2="51.49795" y2="68.00215" layer="21"/>
+<rectangle x1="52.52665" y1="67.98945" x2="52.71715" y2="68.00215" layer="21"/>
+<rectangle x1="54.06335" y1="67.98945" x2="54.41895" y2="68.00215" layer="21"/>
+<rectangle x1="51.14235" y1="68.00215" x2="51.48525" y2="68.01485" layer="21"/>
+<rectangle x1="52.53935" y1="68.00215" x2="52.72985" y2="68.01485" layer="21"/>
+<rectangle x1="54.07605" y1="68.00215" x2="54.43165" y2="68.01485" layer="21"/>
+<rectangle x1="51.12965" y1="68.01485" x2="51.48525" y2="68.02755" layer="21"/>
+<rectangle x1="52.55205" y1="68.01485" x2="52.72985" y2="68.02755" layer="21"/>
+<rectangle x1="54.10145" y1="68.01485" x2="54.45705" y2="68.02755" layer="21"/>
+<rectangle x1="51.11695" y1="68.02755" x2="51.48525" y2="68.04025" layer="21"/>
+<rectangle x1="52.56475" y1="68.02755" x2="52.74255" y2="68.04025" layer="21"/>
+<rectangle x1="54.11415" y1="68.02755" x2="54.45705" y2="68.04025" layer="21"/>
+<rectangle x1="51.10425" y1="68.04025" x2="51.47255" y2="68.05295" layer="21"/>
+<rectangle x1="52.57745" y1="68.04025" x2="52.75525" y2="68.05295" layer="21"/>
+<rectangle x1="54.12685" y1="68.04025" x2="54.46975" y2="68.05295" layer="21"/>
+<rectangle x1="51.09155" y1="68.05295" x2="51.47255" y2="68.06565" layer="21"/>
+<rectangle x1="52.57745" y1="68.05295" x2="52.75525" y2="68.06565" layer="21"/>
+<rectangle x1="54.15225" y1="68.05295" x2="54.49515" y2="68.06565" layer="21"/>
+<rectangle x1="51.07885" y1="68.06565" x2="51.47255" y2="68.07835" layer="21"/>
+<rectangle x1="52.59015" y1="68.06565" x2="52.76795" y2="68.07835" layer="21"/>
+<rectangle x1="54.16495" y1="68.06565" x2="54.49515" y2="68.07835" layer="21"/>
+<rectangle x1="51.06615" y1="68.07835" x2="51.47255" y2="68.09105" layer="21"/>
+<rectangle x1="52.60285" y1="68.07835" x2="52.76795" y2="68.09105" layer="21"/>
+<rectangle x1="52.85685" y1="68.07835" x2="52.86955" y2="68.09105" layer="21"/>
+<rectangle x1="54.17765" y1="68.07835" x2="54.50785" y2="68.09105" layer="21"/>
+<rectangle x1="51.05345" y1="68.09105" x2="51.45985" y2="68.10375" layer="21"/>
+<rectangle x1="51.89165" y1="68.09105" x2="52.01865" y2="68.10375" layer="21"/>
+<rectangle x1="52.61555" y1="68.09105" x2="52.78065" y2="68.10375" layer="21"/>
+<rectangle x1="52.85685" y1="68.09105" x2="52.88225" y2="68.10375" layer="21"/>
+<rectangle x1="54.19035" y1="68.09105" x2="54.52055" y2="68.10375" layer="21"/>
+<rectangle x1="51.04075" y1="68.10375" x2="51.45985" y2="68.11645" layer="21"/>
+<rectangle x1="51.86625" y1="68.10375" x2="52.05675" y2="68.11645" layer="21"/>
+<rectangle x1="52.61555" y1="68.10375" x2="52.78065" y2="68.11645" layer="21"/>
+<rectangle x1="52.85685" y1="68.10375" x2="52.89495" y2="68.11645" layer="21"/>
+<rectangle x1="54.21575" y1="68.10375" x2="54.53325" y2="68.11645" layer="21"/>
+<rectangle x1="51.02805" y1="68.11645" x2="51.45985" y2="68.12915" layer="21"/>
+<rectangle x1="51.85355" y1="68.11645" x2="52.09485" y2="68.12915" layer="21"/>
+<rectangle x1="52.62825" y1="68.11645" x2="52.79335" y2="68.12915" layer="21"/>
+<rectangle x1="52.86955" y1="68.11645" x2="52.90765" y2="68.12915" layer="21"/>
+<rectangle x1="54.22845" y1="68.11645" x2="54.54595" y2="68.12915" layer="21"/>
+<rectangle x1="51.01535" y1="68.12915" x2="51.45985" y2="68.14185" layer="21"/>
+<rectangle x1="51.84085" y1="68.12915" x2="52.12025" y2="68.14185" layer="21"/>
+<rectangle x1="52.62825" y1="68.12915" x2="52.79335" y2="68.14185" layer="21"/>
+<rectangle x1="52.86955" y1="68.12915" x2="52.92035" y2="68.14185" layer="21"/>
+<rectangle x1="54.24115" y1="68.12915" x2="54.55865" y2="68.14185" layer="21"/>
+<rectangle x1="51.01535" y1="68.14185" x2="51.45985" y2="68.15455" layer="21"/>
+<rectangle x1="51.84085" y1="68.14185" x2="52.14565" y2="68.15455" layer="21"/>
+<rectangle x1="52.64095" y1="68.14185" x2="52.80605" y2="68.15455" layer="21"/>
+<rectangle x1="52.86955" y1="68.14185" x2="52.93305" y2="68.15455" layer="21"/>
+<rectangle x1="54.25385" y1="68.14185" x2="54.57135" y2="68.15455" layer="21"/>
+<rectangle x1="50.98995" y1="68.15455" x2="51.30745" y2="68.16725" layer="21"/>
+<rectangle x1="51.32015" y1="68.15455" x2="51.45985" y2="68.16725" layer="21"/>
+<rectangle x1="51.82815" y1="68.15455" x2="52.15835" y2="68.16725" layer="21"/>
+<rectangle x1="52.65365" y1="68.15455" x2="52.81875" y2="68.16725" layer="21"/>
+<rectangle x1="52.86955" y1="68.15455" x2="52.95845" y2="68.16725" layer="21"/>
+<rectangle x1="54.27925" y1="68.15455" x2="54.58405" y2="68.16725" layer="21"/>
+<rectangle x1="50.98995" y1="68.16725" x2="51.29475" y2="68.17995" layer="21"/>
+<rectangle x1="51.32015" y1="68.16725" x2="51.45985" y2="68.17995" layer="21"/>
+<rectangle x1="51.82815" y1="68.16725" x2="52.17105" y2="68.17995" layer="21"/>
+<rectangle x1="52.65365" y1="68.16725" x2="52.81875" y2="68.17995" layer="21"/>
+<rectangle x1="52.88225" y1="68.16725" x2="52.97115" y2="68.17995" layer="21"/>
+<rectangle x1="54.27925" y1="68.16725" x2="54.58405" y2="68.17995" layer="21"/>
+<rectangle x1="50.97725" y1="68.17995" x2="51.28205" y2="68.19265" layer="21"/>
+<rectangle x1="51.32015" y1="68.17995" x2="51.45985" y2="68.19265" layer="21"/>
+<rectangle x1="51.82815" y1="68.17995" x2="52.18375" y2="68.19265" layer="21"/>
+<rectangle x1="52.66635" y1="68.17995" x2="52.81875" y2="68.19265" layer="21"/>
+<rectangle x1="52.88225" y1="68.17995" x2="52.97115" y2="68.19265" layer="21"/>
+<rectangle x1="54.30465" y1="68.17995" x2="54.59675" y2="68.19265" layer="21"/>
+<rectangle x1="50.96455" y1="68.19265" x2="51.25665" y2="68.20535" layer="21"/>
+<rectangle x1="51.32015" y1="68.19265" x2="51.45985" y2="68.20535" layer="21"/>
+<rectangle x1="51.82815" y1="68.19265" x2="52.20915" y2="68.20535" layer="21"/>
+<rectangle x1="52.66635" y1="68.19265" x2="52.83145" y2="68.20535" layer="21"/>
+<rectangle x1="52.88225" y1="68.19265" x2="52.98385" y2="68.20535" layer="21"/>
+<rectangle x1="54.31735" y1="68.19265" x2="54.60945" y2="68.20535" layer="21"/>
+<rectangle x1="50.95185" y1="68.20535" x2="51.24395" y2="68.21805" layer="21"/>
+<rectangle x1="51.32015" y1="68.20535" x2="51.45985" y2="68.21805" layer="21"/>
+<rectangle x1="51.84085" y1="68.20535" x2="52.22185" y2="68.21805" layer="21"/>
+<rectangle x1="52.67905" y1="68.20535" x2="52.83145" y2="68.21805" layer="21"/>
+<rectangle x1="52.88225" y1="68.20535" x2="52.99655" y2="68.21805" layer="21"/>
+<rectangle x1="54.33005" y1="68.20535" x2="54.62215" y2="68.21805" layer="21"/>
+<rectangle x1="50.93915" y1="68.21805" x2="51.24395" y2="68.23075" layer="21"/>
+<rectangle x1="51.32015" y1="68.21805" x2="51.45985" y2="68.23075" layer="21"/>
+<rectangle x1="51.84085" y1="68.21805" x2="52.23455" y2="68.23075" layer="21"/>
+<rectangle x1="52.67905" y1="68.21805" x2="52.84415" y2="68.23075" layer="21"/>
+<rectangle x1="52.89495" y1="68.21805" x2="53.00925" y2="68.23075" layer="21"/>
+<rectangle x1="54.33005" y1="68.21805" x2="54.63485" y2="68.23075" layer="21"/>
+<rectangle x1="50.93915" y1="68.23075" x2="51.23125" y2="68.24345" layer="21"/>
+<rectangle x1="51.32015" y1="68.23075" x2="51.45985" y2="68.24345" layer="21"/>
+<rectangle x1="51.85355" y1="68.23075" x2="52.24725" y2="68.24345" layer="21"/>
+<rectangle x1="52.69175" y1="68.23075" x2="52.84415" y2="68.24345" layer="21"/>
+<rectangle x1="52.89495" y1="68.23075" x2="53.02195" y2="68.24345" layer="21"/>
+<rectangle x1="54.35545" y1="68.23075" x2="54.63485" y2="68.24345" layer="21"/>
+<rectangle x1="50.92645" y1="68.24345" x2="51.21855" y2="68.25615" layer="21"/>
+<rectangle x1="51.32015" y1="68.24345" x2="51.45985" y2="68.25615" layer="21"/>
+<rectangle x1="51.86625" y1="68.24345" x2="52.25995" y2="68.25615" layer="21"/>
+<rectangle x1="52.69175" y1="68.24345" x2="52.85685" y2="68.25615" layer="21"/>
+<rectangle x1="52.90765" y1="68.24345" x2="53.03465" y2="68.25615" layer="21"/>
+<rectangle x1="54.36815" y1="68.24345" x2="54.64755" y2="68.25615" layer="21"/>
+<rectangle x1="50.91375" y1="68.25615" x2="51.20585" y2="68.26885" layer="21"/>
+<rectangle x1="51.32015" y1="68.25615" x2="51.47255" y2="68.26885" layer="21"/>
+<rectangle x1="51.86625" y1="68.25615" x2="52.25995" y2="68.26885" layer="21"/>
+<rectangle x1="52.70445" y1="68.25615" x2="52.85685" y2="68.26885" layer="21"/>
+<rectangle x1="52.90765" y1="68.25615" x2="53.03465" y2="68.26885" layer="21"/>
+<rectangle x1="54.36815" y1="68.25615" x2="54.66025" y2="68.26885" layer="21"/>
+<rectangle x1="50.90105" y1="68.26885" x2="51.19315" y2="68.28155" layer="21"/>
+<rectangle x1="51.32015" y1="68.26885" x2="51.47255" y2="68.28155" layer="21"/>
+<rectangle x1="51.89165" y1="68.26885" x2="52.27265" y2="68.28155" layer="21"/>
+<rectangle x1="52.70445" y1="68.26885" x2="52.86955" y2="68.28155" layer="21"/>
+<rectangle x1="52.90765" y1="68.26885" x2="53.04735" y2="68.28155" layer="21"/>
+<rectangle x1="54.38085" y1="68.26885" x2="54.67295" y2="68.28155" layer="21"/>
+<rectangle x1="50.90105" y1="68.28155" x2="51.18045" y2="68.29425" layer="21"/>
+<rectangle x1="51.32015" y1="68.28155" x2="51.47255" y2="68.29425" layer="21"/>
+<rectangle x1="51.92975" y1="68.28155" x2="52.28535" y2="68.29425" layer="21"/>
+<rectangle x1="52.71715" y1="68.28155" x2="52.86955" y2="68.29425" layer="21"/>
+<rectangle x1="52.92035" y1="68.28155" x2="53.06005" y2="68.29425" layer="21"/>
+<rectangle x1="54.39355" y1="68.28155" x2="54.67295" y2="68.29425" layer="21"/>
+<rectangle x1="50.88835" y1="68.29425" x2="51.16775" y2="68.30695" layer="21"/>
+<rectangle x1="51.33285" y1="68.29425" x2="51.47255" y2="68.30695" layer="21"/>
+<rectangle x1="51.96785" y1="68.29425" x2="52.29805" y2="68.30695" layer="21"/>
+<rectangle x1="52.71715" y1="68.29425" x2="52.88225" y2="68.30695" layer="21"/>
+<rectangle x1="52.92035" y1="68.29425" x2="53.07275" y2="68.30695" layer="21"/>
+<rectangle x1="54.40625" y1="68.29425" x2="54.68565" y2="68.30695" layer="21"/>
+<rectangle x1="50.87565" y1="68.30695" x2="51.15505" y2="68.31965" layer="21"/>
+<rectangle x1="51.33285" y1="68.30695" x2="51.48525" y2="68.31965" layer="21"/>
+<rectangle x1="51.99325" y1="68.30695" x2="52.29805" y2="68.31965" layer="21"/>
+<rectangle x1="52.72985" y1="68.30695" x2="52.88225" y2="68.31965" layer="21"/>
+<rectangle x1="52.92035" y1="68.30695" x2="53.08545" y2="68.31965" layer="21"/>
+<rectangle x1="54.41895" y1="68.30695" x2="54.69835" y2="68.31965" layer="21"/>
+<rectangle x1="50.87565" y1="68.31965" x2="51.14235" y2="68.33235" layer="21"/>
+<rectangle x1="51.33285" y1="68.31965" x2="51.48525" y2="68.33235" layer="21"/>
+<rectangle x1="51.99325" y1="68.31965" x2="52.31075" y2="68.33235" layer="21"/>
+<rectangle x1="52.72985" y1="68.31965" x2="52.88225" y2="68.33235" layer="21"/>
+<rectangle x1="52.93305" y1="68.31965" x2="53.09815" y2="68.33235" layer="21"/>
+<rectangle x1="54.43165" y1="68.31965" x2="54.69835" y2="68.33235" layer="21"/>
+<rectangle x1="50.86295" y1="68.33235" x2="51.12965" y2="68.34505" layer="21"/>
+<rectangle x1="51.33285" y1="68.33235" x2="51.48525" y2="68.34505" layer="21"/>
+<rectangle x1="52.01865" y1="68.33235" x2="52.32345" y2="68.34505" layer="21"/>
+<rectangle x1="52.74255" y1="68.33235" x2="52.89495" y2="68.34505" layer="21"/>
+<rectangle x1="52.93305" y1="68.33235" x2="53.11085" y2="68.34505" layer="21"/>
+<rectangle x1="54.43165" y1="68.33235" x2="54.71105" y2="68.34505" layer="21"/>
+<rectangle x1="50.86295" y1="68.34505" x2="51.12965" y2="68.35775" layer="21"/>
+<rectangle x1="51.34555" y1="68.34505" x2="51.49795" y2="68.35775" layer="21"/>
+<rectangle x1="52.01865" y1="68.34505" x2="52.32345" y2="68.35775" layer="21"/>
+<rectangle x1="52.74255" y1="68.34505" x2="52.89495" y2="68.35775" layer="21"/>
+<rectangle x1="52.93305" y1="68.34505" x2="53.11085" y2="68.35775" layer="21"/>
+<rectangle x1="54.44435" y1="68.34505" x2="54.72375" y2="68.35775" layer="21"/>
+<rectangle x1="50.85025" y1="68.35775" x2="51.10425" y2="68.37045" layer="21"/>
+<rectangle x1="51.34555" y1="68.35775" x2="51.49795" y2="68.37045" layer="21"/>
+<rectangle x1="52.03135" y1="68.35775" x2="52.33615" y2="68.37045" layer="21"/>
+<rectangle x1="52.75525" y1="68.35775" x2="52.90765" y2="68.37045" layer="21"/>
+<rectangle x1="52.94575" y1="68.35775" x2="53.12355" y2="68.37045" layer="21"/>
+<rectangle x1="54.45705" y1="68.35775" x2="54.72375" y2="68.37045" layer="21"/>
+<rectangle x1="50.83755" y1="68.37045" x2="51.10425" y2="68.38315" layer="21"/>
+<rectangle x1="51.35825" y1="68.37045" x2="51.51065" y2="68.38315" layer="21"/>
+<rectangle x1="52.04405" y1="68.37045" x2="52.33615" y2="68.38315" layer="21"/>
+<rectangle x1="52.75525" y1="68.37045" x2="52.90765" y2="68.38315" layer="21"/>
+<rectangle x1="52.94575" y1="68.37045" x2="53.13625" y2="68.38315" layer="21"/>
+<rectangle x1="54.46975" y1="68.37045" x2="54.73645" y2="68.38315" layer="21"/>
+<rectangle x1="50.82485" y1="68.38315" x2="51.09155" y2="68.39585" layer="21"/>
+<rectangle x1="51.35825" y1="68.38315" x2="51.51065" y2="68.39585" layer="21"/>
+<rectangle x1="52.04405" y1="68.38315" x2="52.34885" y2="68.39585" layer="21"/>
+<rectangle x1="52.75525" y1="68.38315" x2="52.90765" y2="68.39585" layer="21"/>
+<rectangle x1="52.95845" y1="68.38315" x2="53.13625" y2="68.39585" layer="21"/>
+<rectangle x1="54.46975" y1="68.38315" x2="54.73645" y2="68.39585" layer="21"/>
+<rectangle x1="50.82485" y1="68.39585" x2="51.07885" y2="68.40855" layer="21"/>
+<rectangle x1="51.35825" y1="68.39585" x2="51.52335" y2="68.40855" layer="21"/>
+<rectangle x1="52.05675" y1="68.39585" x2="52.36155" y2="68.40855" layer="21"/>
+<rectangle x1="52.76795" y1="68.39585" x2="52.92035" y2="68.40855" layer="21"/>
+<rectangle x1="52.95845" y1="68.39585" x2="53.14895" y2="68.40855" layer="21"/>
+<rectangle x1="54.48245" y1="68.39585" x2="54.74915" y2="68.40855" layer="21"/>
+<rectangle x1="50.81215" y1="68.40855" x2="51.07885" y2="68.42125" layer="21"/>
+<rectangle x1="51.37095" y1="68.40855" x2="51.52335" y2="68.42125" layer="21"/>
+<rectangle x1="52.05675" y1="68.40855" x2="52.36155" y2="68.42125" layer="21"/>
+<rectangle x1="52.76795" y1="68.40855" x2="52.92035" y2="68.42125" layer="21"/>
+<rectangle x1="52.97115" y1="68.40855" x2="53.16165" y2="68.42125" layer="21"/>
+<rectangle x1="54.49515" y1="68.40855" x2="54.76185" y2="68.42125" layer="21"/>
+<rectangle x1="50.81215" y1="68.42125" x2="51.06615" y2="68.43395" layer="21"/>
+<rectangle x1="51.37095" y1="68.42125" x2="51.53605" y2="68.43395" layer="21"/>
+<rectangle x1="52.05675" y1="68.42125" x2="52.19645" y2="68.43395" layer="21"/>
+<rectangle x1="52.20915" y1="68.42125" x2="52.37425" y2="68.43395" layer="21"/>
+<rectangle x1="52.76795" y1="68.42125" x2="52.92035" y2="68.43395" layer="21"/>
+<rectangle x1="52.97115" y1="68.42125" x2="53.17435" y2="68.43395" layer="21"/>
+<rectangle x1="54.50785" y1="68.42125" x2="54.76185" y2="68.43395" layer="21"/>
+<rectangle x1="50.79945" y1="68.43395" x2="51.06615" y2="68.44665" layer="21"/>
+<rectangle x1="51.38365" y1="68.43395" x2="51.53605" y2="68.44665" layer="21"/>
+<rectangle x1="52.05675" y1="68.43395" x2="52.20915" y2="68.44665" layer="21"/>
+<rectangle x1="52.22185" y1="68.43395" x2="52.37425" y2="68.44665" layer="21"/>
+<rectangle x1="52.78065" y1="68.43395" x2="52.93305" y2="68.44665" layer="21"/>
+<rectangle x1="52.97115" y1="68.43395" x2="53.17435" y2="68.44665" layer="21"/>
+<rectangle x1="54.50785" y1="68.43395" x2="54.77455" y2="68.44665" layer="21"/>
+<rectangle x1="50.78675" y1="68.44665" x2="51.05345" y2="68.45935" layer="21"/>
+<rectangle x1="51.38365" y1="68.44665" x2="51.54875" y2="68.45935" layer="21"/>
+<rectangle x1="52.05675" y1="68.44665" x2="52.20915" y2="68.45935" layer="21"/>
+<rectangle x1="52.22185" y1="68.44665" x2="52.38695" y2="68.45935" layer="21"/>
+<rectangle x1="52.78065" y1="68.44665" x2="52.93305" y2="68.45935" layer="21"/>
+<rectangle x1="52.98385" y1="68.44665" x2="53.18705" y2="68.45935" layer="21"/>
+<rectangle x1="54.52055" y1="68.44665" x2="54.77455" y2="68.45935" layer="21"/>
+<rectangle x1="50.78675" y1="68.45935" x2="51.04075" y2="68.47205" layer="21"/>
+<rectangle x1="51.38365" y1="68.45935" x2="51.56145" y2="68.47205" layer="21"/>
+<rectangle x1="52.05675" y1="68.45935" x2="52.20915" y2="68.47205" layer="21"/>
+<rectangle x1="52.23455" y1="68.45935" x2="52.38695" y2="68.47205" layer="21"/>
+<rectangle x1="52.78065" y1="68.45935" x2="52.93305" y2="68.47205" layer="21"/>
+<rectangle x1="52.98385" y1="68.45935" x2="53.18705" y2="68.47205" layer="21"/>
+<rectangle x1="54.52055" y1="68.45935" x2="54.78725" y2="68.47205" layer="21"/>
+<rectangle x1="50.77405" y1="68.47205" x2="51.04075" y2="68.48475" layer="21"/>
+<rectangle x1="51.39635" y1="68.47205" x2="51.56145" y2="68.48475" layer="21"/>
+<rectangle x1="52.05675" y1="68.47205" x2="52.20915" y2="68.48475" layer="21"/>
+<rectangle x1="52.23455" y1="68.47205" x2="52.39965" y2="68.48475" layer="21"/>
+<rectangle x1="52.79335" y1="68.47205" x2="52.93305" y2="68.48475" layer="21"/>
+<rectangle x1="52.99655" y1="68.47205" x2="53.19975" y2="68.48475" layer="21"/>
+<rectangle x1="54.53325" y1="68.47205" x2="54.78725" y2="68.48475" layer="21"/>
+<rectangle x1="50.77405" y1="68.48475" x2="51.02805" y2="68.49745" layer="21"/>
+<rectangle x1="51.39635" y1="68.48475" x2="51.57415" y2="68.49745" layer="21"/>
+<rectangle x1="52.05675" y1="68.48475" x2="52.19645" y2="68.49745" layer="21"/>
+<rectangle x1="52.24725" y1="68.48475" x2="52.39965" y2="68.49745" layer="21"/>
+<rectangle x1="52.79335" y1="68.48475" x2="52.94575" y2="68.49745" layer="21"/>
+<rectangle x1="52.99655" y1="68.48475" x2="53.21245" y2="68.49745" layer="21"/>
+<rectangle x1="54.54595" y1="68.48475" x2="54.79995" y2="68.49745" layer="21"/>
+<rectangle x1="50.76135" y1="68.49745" x2="51.01535" y2="68.51015" layer="21"/>
+<rectangle x1="51.40905" y1="68.49745" x2="51.58685" y2="68.51015" layer="21"/>
+<rectangle x1="52.05675" y1="68.49745" x2="52.19645" y2="68.51015" layer="21"/>
+<rectangle x1="52.24725" y1="68.49745" x2="52.39965" y2="68.51015" layer="21"/>
+<rectangle x1="52.79335" y1="68.49745" x2="52.94575" y2="68.51015" layer="21"/>
+<rectangle x1="52.99655" y1="68.49745" x2="53.22515" y2="68.51015" layer="21"/>
+<rectangle x1="54.55865" y1="68.49745" x2="54.81265" y2="68.51015" layer="21"/>
+<rectangle x1="50.76135" y1="68.51015" x2="51.01535" y2="68.52285" layer="21"/>
+<rectangle x1="51.42175" y1="68.51015" x2="51.59955" y2="68.52285" layer="21"/>
+<rectangle x1="52.05675" y1="68.51015" x2="52.19645" y2="68.52285" layer="21"/>
+<rectangle x1="52.25995" y1="68.51015" x2="52.41235" y2="68.52285" layer="21"/>
+<rectangle x1="52.80605" y1="68.51015" x2="52.95845" y2="68.52285" layer="21"/>
+<rectangle x1="53.00925" y1="68.51015" x2="53.23785" y2="68.52285" layer="21"/>
+<rectangle x1="54.55865" y1="68.51015" x2="54.81265" y2="68.52285" layer="21"/>
+<rectangle x1="50.74865" y1="68.52285" x2="51.00265" y2="68.53555" layer="21"/>
+<rectangle x1="51.42175" y1="68.52285" x2="51.61225" y2="68.53555" layer="21"/>
+<rectangle x1="52.04405" y1="68.52285" x2="52.19645" y2="68.53555" layer="21"/>
+<rectangle x1="52.25995" y1="68.52285" x2="52.41235" y2="68.53555" layer="21"/>
+<rectangle x1="52.80605" y1="68.52285" x2="52.95845" y2="68.53555" layer="21"/>
+<rectangle x1="53.02195" y1="68.52285" x2="53.23785" y2="68.53555" layer="21"/>
+<rectangle x1="54.57135" y1="68.52285" x2="54.82535" y2="68.53555" layer="21"/>
+<rectangle x1="50.74865" y1="68.53555" x2="50.98995" y2="68.54825" layer="21"/>
+<rectangle x1="51.43445" y1="68.53555" x2="51.62495" y2="68.54825" layer="21"/>
+<rectangle x1="52.04405" y1="68.53555" x2="52.19645" y2="68.54825" layer="21"/>
+<rectangle x1="52.27265" y1="68.53555" x2="52.42505" y2="68.54825" layer="21"/>
+<rectangle x1="52.80605" y1="68.53555" x2="52.95845" y2="68.54825" layer="21"/>
+<rectangle x1="53.02195" y1="68.53555" x2="53.25055" y2="68.54825" layer="21"/>
+<rectangle x1="54.57135" y1="68.53555" x2="54.82535" y2="68.54825" layer="21"/>
+<rectangle x1="50.73595" y1="68.54825" x2="50.98995" y2="68.56095" layer="21"/>
+<rectangle x1="51.44715" y1="68.54825" x2="51.63765" y2="68.56095" layer="21"/>
+<rectangle x1="52.03135" y1="68.54825" x2="52.18375" y2="68.56095" layer="21"/>
+<rectangle x1="52.27265" y1="68.54825" x2="52.42505" y2="68.56095" layer="21"/>
+<rectangle x1="52.81875" y1="68.54825" x2="52.95845" y2="68.56095" layer="21"/>
+<rectangle x1="53.02195" y1="68.54825" x2="53.26325" y2="68.56095" layer="21"/>
+<rectangle x1="54.58405" y1="68.54825" x2="54.83805" y2="68.56095" layer="21"/>
+<rectangle x1="50.73595" y1="68.56095" x2="50.97725" y2="68.57365" layer="21"/>
+<rectangle x1="51.44715" y1="68.56095" x2="51.65035" y2="68.57365" layer="21"/>
+<rectangle x1="52.03135" y1="68.56095" x2="52.18375" y2="68.57365" layer="21"/>
+<rectangle x1="52.27265" y1="68.56095" x2="52.42505" y2="68.57365" layer="21"/>
+<rectangle x1="52.81875" y1="68.56095" x2="52.97115" y2="68.57365" layer="21"/>
+<rectangle x1="53.03465" y1="68.56095" x2="53.26325" y2="68.57365" layer="21"/>
+<rectangle x1="54.58405" y1="68.56095" x2="54.83805" y2="68.57365" layer="21"/>
+<rectangle x1="50.72325" y1="68.57365" x2="50.97725" y2="68.58635" layer="21"/>
+<rectangle x1="51.45985" y1="68.57365" x2="51.67575" y2="68.58635" layer="21"/>
+<rectangle x1="52.01865" y1="68.57365" x2="52.18375" y2="68.58635" layer="21"/>
+<rectangle x1="52.28535" y1="68.57365" x2="52.42505" y2="68.58635" layer="21"/>
+<rectangle x1="52.81875" y1="68.57365" x2="52.97115" y2="68.58635" layer="21"/>
+<rectangle x1="53.03465" y1="68.57365" x2="53.27595" y2="68.58635" layer="21"/>
+<rectangle x1="54.59675" y1="68.57365" x2="54.85075" y2="68.58635" layer="21"/>
+<rectangle x1="50.72325" y1="68.58635" x2="50.96455" y2="68.59905" layer="21"/>
+<rectangle x1="51.47255" y1="68.58635" x2="51.70115" y2="68.59905" layer="21"/>
+<rectangle x1="52.00595" y1="68.58635" x2="52.17105" y2="68.59905" layer="21"/>
+<rectangle x1="52.28535" y1="68.58635" x2="52.43775" y2="68.59905" layer="21"/>
+<rectangle x1="52.83145" y1="68.58635" x2="52.97115" y2="68.59905" layer="21"/>
+<rectangle x1="53.04735" y1="68.58635" x2="53.28865" y2="68.59905" layer="21"/>
+<rectangle x1="54.59675" y1="68.58635" x2="54.85075" y2="68.59905" layer="21"/>
+<rectangle x1="50.72325" y1="68.59905" x2="50.96455" y2="68.61175" layer="21"/>
+<rectangle x1="51.48525" y1="68.59905" x2="51.71385" y2="68.61175" layer="21"/>
+<rectangle x1="51.99325" y1="68.59905" x2="52.17105" y2="68.61175" layer="21"/>
+<rectangle x1="52.27265" y1="68.59905" x2="52.43775" y2="68.61175" layer="21"/>
+<rectangle x1="52.83145" y1="68.59905" x2="52.97115" y2="68.61175" layer="21"/>
+<rectangle x1="53.04735" y1="68.59905" x2="53.30135" y2="68.61175" layer="21"/>
+<rectangle x1="54.60945" y1="68.59905" x2="54.85075" y2="68.61175" layer="21"/>
+<rectangle x1="50.71055" y1="68.61175" x2="50.96455" y2="68.62445" layer="21"/>
+<rectangle x1="51.49795" y1="68.61175" x2="51.75195" y2="68.62445" layer="21"/>
+<rectangle x1="51.96785" y1="68.61175" x2="52.15835" y2="68.62445" layer="21"/>
+<rectangle x1="52.25995" y1="68.61175" x2="52.43775" y2="68.62445" layer="21"/>
+<rectangle x1="52.83145" y1="68.61175" x2="52.98385" y2="68.62445" layer="21"/>
+<rectangle x1="53.06005" y1="68.61175" x2="53.30135" y2="68.62445" layer="21"/>
+<rectangle x1="54.60945" y1="68.61175" x2="54.86345" y2="68.62445" layer="21"/>
+<rectangle x1="50.69785" y1="68.62445" x2="50.95185" y2="68.63715" layer="21"/>
+<rectangle x1="51.51065" y1="68.62445" x2="51.79005" y2="68.63715" layer="21"/>
+<rectangle x1="51.94245" y1="68.62445" x2="52.14565" y2="68.63715" layer="21"/>
+<rectangle x1="52.25995" y1="68.62445" x2="52.45045" y2="68.63715" layer="21"/>
+<rectangle x1="52.83145" y1="68.62445" x2="52.98385" y2="68.63715" layer="21"/>
+<rectangle x1="53.06005" y1="68.62445" x2="53.31405" y2="68.63715" layer="21"/>
+<rectangle x1="54.62215" y1="68.62445" x2="54.86345" y2="68.63715" layer="21"/>
+<rectangle x1="50.69785" y1="68.63715" x2="50.93915" y2="68.64985" layer="21"/>
+<rectangle x1="51.52335" y1="68.63715" x2="52.14565" y2="68.64985" layer="21"/>
+<rectangle x1="52.24725" y1="68.63715" x2="52.45045" y2="68.64985" layer="21"/>
+<rectangle x1="52.83145" y1="68.63715" x2="52.98385" y2="68.64985" layer="21"/>
+<rectangle x1="53.07275" y1="68.63715" x2="53.32675" y2="68.64985" layer="21"/>
+<rectangle x1="54.62215" y1="68.63715" x2="54.87615" y2="68.64985" layer="21"/>
+<rectangle x1="50.69785" y1="68.64985" x2="50.93915" y2="68.66255" layer="21"/>
+<rectangle x1="51.53605" y1="68.64985" x2="52.13295" y2="68.66255" layer="21"/>
+<rectangle x1="52.23455" y1="68.64985" x2="52.45045" y2="68.66255" layer="21"/>
+<rectangle x1="52.84415" y1="68.64985" x2="52.98385" y2="68.66255" layer="21"/>
+<rectangle x1="53.07275" y1="68.64985" x2="53.33945" y2="68.66255" layer="21"/>
+<rectangle x1="54.63485" y1="68.64985" x2="54.87615" y2="68.66255" layer="21"/>
+<rectangle x1="50.68515" y1="68.66255" x2="50.92645" y2="68.67525" layer="21"/>
+<rectangle x1="51.56145" y1="68.66255" x2="52.13295" y2="68.67525" layer="21"/>
+<rectangle x1="52.22185" y1="68.66255" x2="52.46315" y2="68.67525" layer="21"/>
+<rectangle x1="52.84415" y1="68.66255" x2="52.98385" y2="68.67525" layer="21"/>
+<rectangle x1="53.07275" y1="68.66255" x2="53.33945" y2="68.67525" layer="21"/>
+<rectangle x1="54.63485" y1="68.66255" x2="54.87615" y2="68.67525" layer="21"/>
+<rectangle x1="50.68515" y1="68.67525" x2="50.92645" y2="68.68795" layer="21"/>
+<rectangle x1="51.57415" y1="68.67525" x2="52.12025" y2="68.68795" layer="21"/>
+<rectangle x1="52.20915" y1="68.67525" x2="52.46315" y2="68.68795" layer="21"/>
+<rectangle x1="52.84415" y1="68.67525" x2="52.99655" y2="68.68795" layer="21"/>
+<rectangle x1="53.08545" y1="68.67525" x2="53.36485" y2="68.68795" layer="21"/>
+<rectangle x1="54.64755" y1="68.67525" x2="54.88885" y2="68.68795" layer="21"/>
+<rectangle x1="50.67245" y1="68.68795" x2="50.92645" y2="68.70065" layer="21"/>
+<rectangle x1="51.58685" y1="68.68795" x2="52.09485" y2="68.70065" layer="21"/>
+<rectangle x1="52.19645" y1="68.68795" x2="52.46315" y2="68.70065" layer="21"/>
+<rectangle x1="52.84415" y1="68.68795" x2="52.99655" y2="68.70065" layer="21"/>
+<rectangle x1="53.08545" y1="68.68795" x2="53.37755" y2="68.70065" layer="21"/>
+<rectangle x1="54.64755" y1="68.68795" x2="54.90155" y2="68.70065" layer="21"/>
+<rectangle x1="50.67245" y1="68.70065" x2="50.91375" y2="68.71335" layer="21"/>
+<rectangle x1="51.61225" y1="68.70065" x2="52.08215" y2="68.71335" layer="21"/>
+<rectangle x1="52.18375" y1="68.70065" x2="52.46315" y2="68.71335" layer="21"/>
+<rectangle x1="52.85685" y1="68.70065" x2="52.99655" y2="68.71335" layer="21"/>
+<rectangle x1="53.09815" y1="68.70065" x2="53.37755" y2="68.71335" layer="21"/>
+<rectangle x1="54.66025" y1="68.70065" x2="54.90155" y2="68.71335" layer="21"/>
+<rectangle x1="50.67245" y1="68.71335" x2="50.91375" y2="68.72605" layer="21"/>
+<rectangle x1="51.63765" y1="68.71335" x2="52.06945" y2="68.72605" layer="21"/>
+<rectangle x1="52.18375" y1="68.71335" x2="52.47585" y2="68.72605" layer="21"/>
+<rectangle x1="52.85685" y1="68.71335" x2="52.99655" y2="68.72605" layer="21"/>
+<rectangle x1="53.09815" y1="68.71335" x2="53.39025" y2="68.72605" layer="21"/>
+<rectangle x1="54.66025" y1="68.71335" x2="54.90155" y2="68.72605" layer="21"/>
+<rectangle x1="50.65975" y1="68.72605" x2="50.90105" y2="68.73875" layer="21"/>
+<rectangle x1="51.66305" y1="68.72605" x2="52.05675" y2="68.73875" layer="21"/>
+<rectangle x1="52.17105" y1="68.72605" x2="52.47585" y2="68.73875" layer="21"/>
+<rectangle x1="52.85685" y1="68.72605" x2="53.00925" y2="68.73875" layer="21"/>
+<rectangle x1="53.09815" y1="68.72605" x2="53.40295" y2="68.73875" layer="21"/>
+<rectangle x1="54.67295" y1="68.72605" x2="54.91425" y2="68.73875" layer="21"/>
+<rectangle x1="50.65975" y1="68.73875" x2="50.90105" y2="68.75145" layer="21"/>
+<rectangle x1="51.70115" y1="68.73875" x2="52.03135" y2="68.75145" layer="21"/>
+<rectangle x1="52.14565" y1="68.73875" x2="52.47585" y2="68.75145" layer="21"/>
+<rectangle x1="52.86955" y1="68.73875" x2="53.00925" y2="68.75145" layer="21"/>
+<rectangle x1="53.11085" y1="68.73875" x2="53.41565" y2="68.75145" layer="21"/>
+<rectangle x1="54.67295" y1="68.73875" x2="54.91425" y2="68.75145" layer="21"/>
+<rectangle x1="50.65975" y1="68.75145" x2="50.88835" y2="68.76415" layer="21"/>
+<rectangle x1="51.71385" y1="68.75145" x2="52.01865" y2="68.76415" layer="21"/>
+<rectangle x1="52.14565" y1="68.75145" x2="52.47585" y2="68.76415" layer="21"/>
+<rectangle x1="52.86955" y1="68.75145" x2="53.00925" y2="68.76415" layer="21"/>
+<rectangle x1="53.11085" y1="68.75145" x2="53.42835" y2="68.76415" layer="21"/>
+<rectangle x1="54.67295" y1="68.75145" x2="54.91425" y2="68.76415" layer="21"/>
+<rectangle x1="50.64705" y1="68.76415" x2="50.88835" y2="68.77685" layer="21"/>
+<rectangle x1="51.76465" y1="68.76415" x2="51.98055" y2="68.77685" layer="21"/>
+<rectangle x1="52.13295" y1="68.76415" x2="52.48855" y2="68.77685" layer="21"/>
+<rectangle x1="52.86955" y1="68.76415" x2="53.02195" y2="68.77685" layer="21"/>
+<rectangle x1="53.12355" y1="68.76415" x2="53.44105" y2="68.77685" layer="21"/>
+<rectangle x1="54.68565" y1="68.76415" x2="54.92695" y2="68.77685" layer="21"/>
+<rectangle x1="50.64705" y1="68.77685" x2="50.88835" y2="68.78955" layer="21"/>
+<rectangle x1="51.82815" y1="68.77685" x2="51.91705" y2="68.78955" layer="21"/>
+<rectangle x1="52.12025" y1="68.77685" x2="52.48855" y2="68.78955" layer="21"/>
+<rectangle x1="52.86955" y1="68.77685" x2="53.02195" y2="68.78955" layer="21"/>
+<rectangle x1="53.12355" y1="68.77685" x2="53.46645" y2="68.78955" layer="21"/>
+<rectangle x1="54.68565" y1="68.77685" x2="54.92695" y2="68.78955" layer="21"/>
+<rectangle x1="50.63435" y1="68.78955" x2="50.87565" y2="68.80225" layer="21"/>
+<rectangle x1="52.09485" y1="68.78955" x2="52.48855" y2="68.80225" layer="21"/>
+<rectangle x1="52.88225" y1="68.78955" x2="53.02195" y2="68.80225" layer="21"/>
+<rectangle x1="53.12355" y1="68.78955" x2="53.47915" y2="68.80225" layer="21"/>
+<rectangle x1="54.69835" y1="68.78955" x2="54.92695" y2="68.80225" layer="21"/>
+<rectangle x1="50.63435" y1="68.80225" x2="50.87565" y2="68.81495" layer="21"/>
+<rectangle x1="52.09485" y1="68.80225" x2="52.48855" y2="68.81495" layer="21"/>
+<rectangle x1="52.88225" y1="68.80225" x2="53.02195" y2="68.81495" layer="21"/>
+<rectangle x1="53.13625" y1="68.80225" x2="53.49185" y2="68.81495" layer="21"/>
+<rectangle x1="54.69835" y1="68.80225" x2="54.92695" y2="68.81495" layer="21"/>
+<rectangle x1="50.63435" y1="68.81495" x2="50.87565" y2="68.82765" layer="21"/>
+<rectangle x1="52.06945" y1="68.81495" x2="52.50125" y2="68.82765" layer="21"/>
+<rectangle x1="52.88225" y1="68.81495" x2="53.03465" y2="68.82765" layer="21"/>
+<rectangle x1="53.13625" y1="68.81495" x2="53.50455" y2="68.82765" layer="21"/>
+<rectangle x1="54.69835" y1="68.81495" x2="54.93965" y2="68.82765" layer="21"/>
+<rectangle x1="50.62165" y1="68.82765" x2="50.86295" y2="68.84035" layer="21"/>
+<rectangle x1="52.05675" y1="68.82765" x2="52.50125" y2="68.84035" layer="21"/>
+<rectangle x1="52.88225" y1="68.82765" x2="53.03465" y2="68.84035" layer="21"/>
+<rectangle x1="53.13625" y1="68.82765" x2="53.51725" y2="68.84035" layer="21"/>
+<rectangle x1="54.71105" y1="68.82765" x2="54.93965" y2="68.84035" layer="21"/>
+<rectangle x1="50.62165" y1="68.84035" x2="50.86295" y2="68.85305" layer="21"/>
+<rectangle x1="52.04405" y1="68.84035" x2="52.50125" y2="68.85305" layer="21"/>
+<rectangle x1="52.89495" y1="68.84035" x2="53.03465" y2="68.85305" layer="21"/>
+<rectangle x1="53.14895" y1="68.84035" x2="53.54265" y2="68.85305" layer="21"/>
+<rectangle x1="54.71105" y1="68.84035" x2="54.95235" y2="68.85305" layer="21"/>
+<rectangle x1="50.62165" y1="68.85305" x2="50.86295" y2="68.86575" layer="21"/>
+<rectangle x1="52.01865" y1="68.85305" x2="52.50125" y2="68.86575" layer="21"/>
+<rectangle x1="52.89495" y1="68.85305" x2="53.04735" y2="68.86575" layer="21"/>
+<rectangle x1="53.14895" y1="68.85305" x2="53.55535" y2="68.86575" layer="21"/>
+<rectangle x1="54.71105" y1="68.85305" x2="54.95235" y2="68.86575" layer="21"/>
+<rectangle x1="50.62165" y1="68.86575" x2="50.85025" y2="68.87845" layer="21"/>
+<rectangle x1="52.01865" y1="68.86575" x2="52.51395" y2="68.87845" layer="21"/>
+<rectangle x1="52.89495" y1="68.86575" x2="53.04735" y2="68.87845" layer="21"/>
+<rectangle x1="53.14895" y1="68.86575" x2="53.56805" y2="68.87845" layer="21"/>
+<rectangle x1="54.72375" y1="68.86575" x2="54.95235" y2="68.87845" layer="21"/>
+<rectangle x1="50.60895" y1="68.87845" x2="50.85025" y2="68.89115" layer="21"/>
+<rectangle x1="51.99325" y1="68.87845" x2="52.51395" y2="68.89115" layer="21"/>
+<rectangle x1="52.90765" y1="68.87845" x2="53.04735" y2="68.89115" layer="21"/>
+<rectangle x1="53.16165" y1="68.87845" x2="53.59345" y2="68.89115" layer="21"/>
+<rectangle x1="54.72375" y1="68.87845" x2="54.96505" y2="68.89115" layer="21"/>
+<rectangle x1="50.60895" y1="68.89115" x2="50.85025" y2="68.90385" layer="21"/>
+<rectangle x1="51.96785" y1="68.89115" x2="52.51395" y2="68.90385" layer="21"/>
+<rectangle x1="52.90765" y1="68.89115" x2="53.06005" y2="68.90385" layer="21"/>
+<rectangle x1="53.16165" y1="68.89115" x2="53.61885" y2="68.90385" layer="21"/>
+<rectangle x1="54.72375" y1="68.89115" x2="54.96505" y2="68.90385" layer="21"/>
+<rectangle x1="50.60895" y1="68.90385" x2="50.83755" y2="68.91655" layer="21"/>
+<rectangle x1="51.95515" y1="68.90385" x2="52.52665" y2="68.91655" layer="21"/>
+<rectangle x1="52.90765" y1="68.90385" x2="53.06005" y2="68.91655" layer="21"/>
+<rectangle x1="53.16165" y1="68.90385" x2="53.63155" y2="68.91655" layer="21"/>
+<rectangle x1="54.72375" y1="68.90385" x2="54.96505" y2="68.91655" layer="21"/>
+<rectangle x1="50.59625" y1="68.91655" x2="50.83755" y2="68.92925" layer="21"/>
+<rectangle x1="51.92975" y1="68.91655" x2="52.52665" y2="68.92925" layer="21"/>
+<rectangle x1="52.90765" y1="68.91655" x2="53.06005" y2="68.92925" layer="21"/>
+<rectangle x1="53.17435" y1="68.91655" x2="53.65695" y2="68.92925" layer="21"/>
+<rectangle x1="54.72375" y1="68.91655" x2="54.97775" y2="68.92925" layer="21"/>
+<rectangle x1="50.59625" y1="68.92925" x2="50.83755" y2="68.94195" layer="21"/>
+<rectangle x1="51.91705" y1="68.92925" x2="52.52665" y2="68.94195" layer="21"/>
+<rectangle x1="52.92035" y1="68.92925" x2="53.06005" y2="68.94195" layer="21"/>
+<rectangle x1="53.17435" y1="68.92925" x2="53.68235" y2="68.94195" layer="21"/>
+<rectangle x1="54.71105" y1="68.92925" x2="54.97775" y2="68.94195" layer="21"/>
+<rectangle x1="50.59625" y1="68.94195" x2="50.83755" y2="68.95465" layer="21"/>
+<rectangle x1="51.89165" y1="68.94195" x2="52.52665" y2="68.95465" layer="21"/>
+<rectangle x1="52.92035" y1="68.94195" x2="53.07275" y2="68.95465" layer="21"/>
+<rectangle x1="53.17435" y1="68.94195" x2="53.69505" y2="68.95465" layer="21"/>
+<rectangle x1="54.69835" y1="68.94195" x2="54.97775" y2="68.95465" layer="21"/>
+<rectangle x1="50.59625" y1="68.95465" x2="50.85025" y2="68.96735" layer="21"/>
+<rectangle x1="51.87895" y1="68.95465" x2="52.53935" y2="68.96735" layer="21"/>
+<rectangle x1="52.92035" y1="68.95465" x2="53.07275" y2="68.96735" layer="21"/>
+<rectangle x1="53.17435" y1="68.95465" x2="53.72045" y2="68.96735" layer="21"/>
+<rectangle x1="54.67295" y1="68.95465" x2="54.97775" y2="68.96735" layer="21"/>
+<rectangle x1="50.59625" y1="68.96735" x2="50.87565" y2="68.98005" layer="21"/>
+<rectangle x1="51.84085" y1="68.96735" x2="52.38695" y2="68.98005" layer="21"/>
+<rectangle x1="52.39965" y1="68.96735" x2="52.53935" y2="68.98005" layer="21"/>
+<rectangle x1="52.92035" y1="68.96735" x2="53.07275" y2="68.98005" layer="21"/>
+<rectangle x1="53.18705" y1="68.96735" x2="53.75855" y2="68.98005" layer="21"/>
+<rectangle x1="54.63485" y1="68.96735" x2="54.97775" y2="68.98005" layer="21"/>
+<rectangle x1="50.58355" y1="68.98005" x2="50.91375" y2="68.99275" layer="21"/>
+<rectangle x1="51.81545" y1="68.98005" x2="52.38695" y2="68.99275" layer="21"/>
+<rectangle x1="52.39965" y1="68.98005" x2="52.53935" y2="68.99275" layer="21"/>
+<rectangle x1="52.93305" y1="68.98005" x2="53.07275" y2="68.99275" layer="21"/>
+<rectangle x1="53.18705" y1="68.98005" x2="53.78395" y2="68.99275" layer="21"/>
+<rectangle x1="54.60945" y1="68.98005" x2="54.97775" y2="68.99275" layer="21"/>
+<rectangle x1="50.58355" y1="68.99275" x2="50.93915" y2="69.00545" layer="21"/>
+<rectangle x1="51.79005" y1="68.99275" x2="52.37425" y2="69.00545" layer="21"/>
+<rectangle x1="52.39965" y1="68.99275" x2="52.53935" y2="69.00545" layer="21"/>
+<rectangle x1="52.93305" y1="68.99275" x2="53.07275" y2="69.00545" layer="21"/>
+<rectangle x1="53.18705" y1="68.99275" x2="53.82205" y2="69.00545" layer="21"/>
+<rectangle x1="54.57135" y1="68.99275" x2="54.97775" y2="69.00545" layer="21"/>
+<rectangle x1="50.58355" y1="69.00545" x2="50.97725" y2="69.01815" layer="21"/>
+<rectangle x1="51.75195" y1="69.00545" x2="52.37425" y2="69.01815" layer="21"/>
+<rectangle x1="52.39965" y1="69.00545" x2="52.55205" y2="69.01815" layer="21"/>
+<rectangle x1="52.93305" y1="69.00545" x2="53.08545" y2="69.01815" layer="21"/>
+<rectangle x1="53.18705" y1="69.00545" x2="53.86015" y2="69.01815" layer="21"/>
+<rectangle x1="54.53325" y1="69.00545" x2="54.97775" y2="69.01815" layer="21"/>
+<rectangle x1="50.59625" y1="69.01815" x2="51.01535" y2="69.03085" layer="21"/>
+<rectangle x1="51.72655" y1="69.01815" x2="52.37425" y2="69.03085" layer="21"/>
+<rectangle x1="52.41235" y1="69.01815" x2="52.55205" y2="69.03085" layer="21"/>
+<rectangle x1="52.93305" y1="69.01815" x2="53.08545" y2="69.03085" layer="21"/>
+<rectangle x1="53.18705" y1="69.01815" x2="53.88555" y2="69.03085" layer="21"/>
+<rectangle x1="54.49515" y1="69.01815" x2="54.97775" y2="69.03085" layer="21"/>
+<rectangle x1="50.59625" y1="69.03085" x2="51.05345" y2="69.04355" layer="21"/>
+<rectangle x1="51.68845" y1="69.03085" x2="52.37425" y2="69.04355" layer="21"/>
+<rectangle x1="52.41235" y1="69.03085" x2="52.55205" y2="69.04355" layer="21"/>
+<rectangle x1="52.94575" y1="69.03085" x2="53.09815" y2="69.04355" layer="21"/>
+<rectangle x1="53.19975" y1="69.03085" x2="53.93635" y2="69.04355" layer="21"/>
+<rectangle x1="54.44435" y1="69.03085" x2="54.96505" y2="69.04355" layer="21"/>
+<rectangle x1="50.59625" y1="69.04355" x2="51.10425" y2="69.05625" layer="21"/>
+<rectangle x1="51.63765" y1="69.04355" x2="52.37425" y2="69.05625" layer="21"/>
+<rectangle x1="52.41235" y1="69.04355" x2="52.56475" y2="69.05625" layer="21"/>
+<rectangle x1="52.94575" y1="69.04355" x2="53.09815" y2="69.05625" layer="21"/>
+<rectangle x1="53.19975" y1="69.04355" x2="53.42835" y2="69.05625" layer="21"/>
+<rectangle x1="53.44105" y1="69.04355" x2="54.01255" y2="69.05625" layer="21"/>
+<rectangle x1="54.38085" y1="69.04355" x2="54.96505" y2="69.05625" layer="21"/>
+<rectangle x1="50.59625" y1="69.05625" x2="51.14235" y2="69.06895" layer="21"/>
+<rectangle x1="51.59955" y1="69.05625" x2="52.37425" y2="69.06895" layer="21"/>
+<rectangle x1="52.41235" y1="69.05625" x2="52.56475" y2="69.06895" layer="21"/>
+<rectangle x1="52.94575" y1="69.05625" x2="53.09815" y2="69.06895" layer="21"/>
+<rectangle x1="53.19975" y1="69.05625" x2="53.42835" y2="69.06895" layer="21"/>
+<rectangle x1="53.45375" y1="69.05625" x2="54.07605" y2="69.06895" layer="21"/>
+<rectangle x1="54.31735" y1="69.05625" x2="54.95235" y2="69.06895" layer="21"/>
+<rectangle x1="50.60895" y1="69.06895" x2="51.21855" y2="69.08165" layer="21"/>
+<rectangle x1="51.53605" y1="69.06895" x2="52.10755" y2="69.08165" layer="21"/>
+<rectangle x1="52.13295" y1="69.06895" x2="52.36155" y2="69.08165" layer="21"/>
+<rectangle x1="52.41235" y1="69.06895" x2="52.56475" y2="69.08165" layer="21"/>
+<rectangle x1="52.95845" y1="69.06895" x2="53.09815" y2="69.08165" layer="21"/>
+<rectangle x1="53.19975" y1="69.06895" x2="53.42835" y2="69.08165" layer="21"/>
+<rectangle x1="53.46645" y1="69.06895" x2="54.93965" y2="69.08165" layer="21"/>
+<rectangle x1="50.62165" y1="69.08165" x2="52.08215" y2="69.09435" layer="21"/>
+<rectangle x1="52.13295" y1="69.08165" x2="52.36155" y2="69.09435" layer="21"/>
+<rectangle x1="52.42505" y1="69.08165" x2="52.56475" y2="69.09435" layer="21"/>
+<rectangle x1="52.95845" y1="69.08165" x2="53.09815" y2="69.09435" layer="21"/>
+<rectangle x1="53.19975" y1="69.08165" x2="53.44105" y2="69.09435" layer="21"/>
+<rectangle x1="53.49185" y1="69.08165" x2="54.92695" y2="69.09435" layer="21"/>
+<rectangle x1="50.62165" y1="69.09435" x2="52.06945" y2="69.10705" layer="21"/>
+<rectangle x1="52.13295" y1="69.09435" x2="52.36155" y2="69.10705" layer="21"/>
+<rectangle x1="52.42505" y1="69.09435" x2="52.56475" y2="69.10705" layer="21"/>
+<rectangle x1="52.95845" y1="69.09435" x2="53.11085" y2="69.10705" layer="21"/>
+<rectangle x1="53.19975" y1="69.09435" x2="53.44105" y2="69.10705" layer="21"/>
+<rectangle x1="53.50455" y1="69.09435" x2="54.91425" y2="69.10705" layer="21"/>
+<rectangle x1="50.63435" y1="69.10705" x2="52.05675" y2="69.11975" layer="21"/>
+<rectangle x1="52.13295" y1="69.10705" x2="52.36155" y2="69.11975" layer="21"/>
+<rectangle x1="52.42505" y1="69.10705" x2="52.57745" y2="69.11975" layer="21"/>
+<rectangle x1="52.95845" y1="69.10705" x2="53.11085" y2="69.11975" layer="21"/>
+<rectangle x1="53.19975" y1="69.10705" x2="53.44105" y2="69.11975" layer="21"/>
+<rectangle x1="53.52995" y1="69.10705" x2="54.90155" y2="69.11975" layer="21"/>
+<rectangle x1="50.65975" y1="69.11975" x2="52.03135" y2="69.13245" layer="21"/>
+<rectangle x1="52.12025" y1="69.11975" x2="52.36155" y2="69.13245" layer="21"/>
+<rectangle x1="52.42505" y1="69.11975" x2="52.57745" y2="69.13245" layer="21"/>
+<rectangle x1="52.97115" y1="69.11975" x2="53.11085" y2="69.13245" layer="21"/>
+<rectangle x1="53.21245" y1="69.11975" x2="53.44105" y2="69.13245" layer="21"/>
+<rectangle x1="53.55535" y1="69.11975" x2="54.90155" y2="69.13245" layer="21"/>
+<rectangle x1="50.68515" y1="69.13245" x2="52.00595" y2="69.14515" layer="21"/>
+<rectangle x1="52.12025" y1="69.13245" x2="52.36155" y2="69.14515" layer="21"/>
+<rectangle x1="52.43775" y1="69.13245" x2="52.57745" y2="69.14515" layer="21"/>
+<rectangle x1="52.97115" y1="69.13245" x2="53.11085" y2="69.14515" layer="21"/>
+<rectangle x1="53.21245" y1="69.13245" x2="53.44105" y2="69.14515" layer="21"/>
+<rectangle x1="53.58075" y1="69.13245" x2="54.91425" y2="69.14515" layer="21"/>
+<rectangle x1="50.68515" y1="69.14515" x2="51.98055" y2="69.15785" layer="21"/>
+<rectangle x1="52.12025" y1="69.14515" x2="52.36155" y2="69.15785" layer="21"/>
+<rectangle x1="52.43775" y1="69.14515" x2="52.59015" y2="69.15785" layer="21"/>
+<rectangle x1="52.97115" y1="69.14515" x2="53.12355" y2="69.15785" layer="21"/>
+<rectangle x1="53.21245" y1="69.14515" x2="53.44105" y2="69.15785" layer="21"/>
+<rectangle x1="53.60615" y1="69.14515" x2="54.91425" y2="69.15785" layer="21"/>
+<rectangle x1="50.68515" y1="69.15785" x2="51.95515" y2="69.17055" layer="21"/>
+<rectangle x1="52.12025" y1="69.15785" x2="52.36155" y2="69.17055" layer="21"/>
+<rectangle x1="52.43775" y1="69.15785" x2="52.59015" y2="69.17055" layer="21"/>
+<rectangle x1="52.97115" y1="69.15785" x2="53.12355" y2="69.17055" layer="21"/>
+<rectangle x1="53.21245" y1="69.15785" x2="53.44105" y2="69.17055" layer="21"/>
+<rectangle x1="53.63155" y1="69.15785" x2="54.91425" y2="69.17055" layer="21"/>
+<rectangle x1="50.67245" y1="69.17055" x2="51.92975" y2="69.18325" layer="21"/>
+<rectangle x1="52.12025" y1="69.17055" x2="52.36155" y2="69.18325" layer="21"/>
+<rectangle x1="52.43775" y1="69.17055" x2="52.59015" y2="69.18325" layer="21"/>
+<rectangle x1="52.98385" y1="69.17055" x2="53.12355" y2="69.18325" layer="21"/>
+<rectangle x1="53.21245" y1="69.17055" x2="53.44105" y2="69.18325" layer="21"/>
+<rectangle x1="53.65695" y1="69.17055" x2="54.92695" y2="69.18325" layer="21"/>
+<rectangle x1="50.67245" y1="69.18325" x2="51.90435" y2="69.19595" layer="21"/>
+<rectangle x1="52.12025" y1="69.18325" x2="52.34885" y2="69.19595" layer="21"/>
+<rectangle x1="52.45045" y1="69.18325" x2="52.59015" y2="69.19595" layer="21"/>
+<rectangle x1="52.98385" y1="69.18325" x2="53.12355" y2="69.19595" layer="21"/>
+<rectangle x1="53.21245" y1="69.18325" x2="53.45375" y2="69.19595" layer="21"/>
+<rectangle x1="53.68235" y1="69.18325" x2="54.92695" y2="69.19595" layer="21"/>
+<rectangle x1="50.67245" y1="69.19595" x2="51.89165" y2="69.20865" layer="21"/>
+<rectangle x1="52.12025" y1="69.19595" x2="52.34885" y2="69.20865" layer="21"/>
+<rectangle x1="52.45045" y1="69.19595" x2="52.59015" y2="69.20865" layer="21"/>
+<rectangle x1="52.98385" y1="69.19595" x2="53.13625" y2="69.20865" layer="21"/>
+<rectangle x1="53.21245" y1="69.19595" x2="53.45375" y2="69.20865" layer="21"/>
+<rectangle x1="53.70775" y1="69.19595" x2="54.92695" y2="69.20865" layer="21"/>
+<rectangle x1="50.65975" y1="69.20865" x2="51.85355" y2="69.22135" layer="21"/>
+<rectangle x1="52.12025" y1="69.20865" x2="52.34885" y2="69.22135" layer="21"/>
+<rectangle x1="52.45045" y1="69.20865" x2="52.60285" y2="69.22135" layer="21"/>
+<rectangle x1="52.98385" y1="69.20865" x2="53.13625" y2="69.22135" layer="21"/>
+<rectangle x1="53.21245" y1="69.20865" x2="53.45375" y2="69.22135" layer="21"/>
+<rectangle x1="53.74585" y1="69.20865" x2="54.64755" y2="69.22135" layer="21"/>
+<rectangle x1="54.68565" y1="69.20865" x2="54.93965" y2="69.22135" layer="21"/>
+<rectangle x1="50.65975" y1="69.22135" x2="51.81545" y2="69.23405" layer="21"/>
+<rectangle x1="52.12025" y1="69.22135" x2="52.34885" y2="69.23405" layer="21"/>
+<rectangle x1="52.46315" y1="69.22135" x2="52.60285" y2="69.23405" layer="21"/>
+<rectangle x1="52.99655" y1="69.22135" x2="53.13625" y2="69.23405" layer="21"/>
+<rectangle x1="53.21245" y1="69.22135" x2="53.45375" y2="69.23405" layer="21"/>
+<rectangle x1="53.78395" y1="69.22135" x2="54.59675" y2="69.23405" layer="21"/>
+<rectangle x1="54.69835" y1="69.22135" x2="54.93965" y2="69.23405" layer="21"/>
+<rectangle x1="50.65975" y1="69.23405" x2="50.90105" y2="69.24675" layer="21"/>
+<rectangle x1="50.92645" y1="69.23405" x2="51.79005" y2="69.24675" layer="21"/>
+<rectangle x1="52.12025" y1="69.23405" x2="52.34885" y2="69.24675" layer="21"/>
+<rectangle x1="52.46315" y1="69.23405" x2="52.60285" y2="69.24675" layer="21"/>
+<rectangle x1="52.99655" y1="69.23405" x2="53.13625" y2="69.24675" layer="21"/>
+<rectangle x1="53.21245" y1="69.23405" x2="53.45375" y2="69.24675" layer="21"/>
+<rectangle x1="53.82205" y1="69.23405" x2="54.57135" y2="69.24675" layer="21"/>
+<rectangle x1="54.69835" y1="69.23405" x2="54.95235" y2="69.24675" layer="21"/>
+<rectangle x1="50.64705" y1="69.24675" x2="50.90105" y2="69.25945" layer="21"/>
+<rectangle x1="50.97725" y1="69.24675" x2="51.75195" y2="69.25945" layer="21"/>
+<rectangle x1="52.12025" y1="69.24675" x2="52.34885" y2="69.25945" layer="21"/>
+<rectangle x1="52.46315" y1="69.24675" x2="52.61555" y2="69.25945" layer="21"/>
+<rectangle x1="52.99655" y1="69.24675" x2="53.14895" y2="69.25945" layer="21"/>
+<rectangle x1="53.21245" y1="69.24675" x2="53.45375" y2="69.25945" layer="21"/>
+<rectangle x1="53.86015" y1="69.24675" x2="54.52055" y2="69.25945" layer="21"/>
+<rectangle x1="54.71105" y1="69.24675" x2="54.95235" y2="69.25945" layer="21"/>
+<rectangle x1="50.63435" y1="69.25945" x2="50.88835" y2="69.27215" layer="21"/>
+<rectangle x1="51.02805" y1="69.25945" x2="51.71385" y2="69.27215" layer="21"/>
+<rectangle x1="52.12025" y1="69.25945" x2="52.34885" y2="69.27215" layer="21"/>
+<rectangle x1="52.46315" y1="69.25945" x2="52.61555" y2="69.27215" layer="21"/>
+<rectangle x1="52.99655" y1="69.25945" x2="53.14895" y2="69.27215" layer="21"/>
+<rectangle x1="53.21245" y1="69.25945" x2="53.45375" y2="69.27215" layer="21"/>
+<rectangle x1="53.92365" y1="69.25945" x2="54.46975" y2="69.27215" layer="21"/>
+<rectangle x1="54.71105" y1="69.25945" x2="54.96505" y2="69.27215" layer="21"/>
+<rectangle x1="50.63435" y1="69.27215" x2="50.88835" y2="69.28485" layer="21"/>
+<rectangle x1="51.07885" y1="69.27215" x2="51.65035" y2="69.28485" layer="21"/>
+<rectangle x1="52.12025" y1="69.27215" x2="52.34885" y2="69.28485" layer="21"/>
+<rectangle x1="52.47585" y1="69.27215" x2="52.61555" y2="69.28485" layer="21"/>
+<rectangle x1="52.99655" y1="69.27215" x2="53.14895" y2="69.28485" layer="21"/>
+<rectangle x1="53.21245" y1="69.27215" x2="53.45375" y2="69.28485" layer="21"/>
+<rectangle x1="53.99985" y1="69.27215" x2="54.46975" y2="69.28485" layer="21"/>
+<rectangle x1="54.71105" y1="69.27215" x2="54.96505" y2="69.28485" layer="21"/>
+<rectangle x1="50.63435" y1="69.28485" x2="50.87565" y2="69.29755" layer="21"/>
+<rectangle x1="51.11695" y1="69.28485" x2="51.56145" y2="69.29755" layer="21"/>
+<rectangle x1="52.12025" y1="69.28485" x2="52.34885" y2="69.29755" layer="21"/>
+<rectangle x1="52.47585" y1="69.28485" x2="52.61555" y2="69.29755" layer="21"/>
+<rectangle x1="53.00925" y1="69.28485" x2="53.16165" y2="69.29755" layer="21"/>
+<rectangle x1="53.21245" y1="69.28485" x2="53.45375" y2="69.29755" layer="21"/>
+<rectangle x1="54.24115" y1="69.28485" x2="54.46975" y2="69.29755" layer="21"/>
+<rectangle x1="54.72375" y1="69.28485" x2="54.97775" y2="69.29755" layer="21"/>
+<rectangle x1="50.62165" y1="69.29755" x2="50.87565" y2="69.31025" layer="21"/>
+<rectangle x1="51.11695" y1="69.29755" x2="51.47255" y2="69.31025" layer="21"/>
+<rectangle x1="52.12025" y1="69.29755" x2="52.34885" y2="69.31025" layer="21"/>
+<rectangle x1="52.47585" y1="69.29755" x2="52.62825" y2="69.31025" layer="21"/>
+<rectangle x1="53.00925" y1="69.29755" x2="53.16165" y2="69.31025" layer="21"/>
+<rectangle x1="53.21245" y1="69.29755" x2="53.45375" y2="69.31025" layer="21"/>
+<rectangle x1="54.24115" y1="69.29755" x2="54.46975" y2="69.31025" layer="21"/>
+<rectangle x1="54.72375" y1="69.29755" x2="54.97775" y2="69.31025" layer="21"/>
+<rectangle x1="50.62165" y1="69.31025" x2="50.87565" y2="69.32295" layer="21"/>
+<rectangle x1="51.11695" y1="69.31025" x2="51.35825" y2="69.32295" layer="21"/>
+<rectangle x1="52.12025" y1="69.31025" x2="52.36155" y2="69.32295" layer="21"/>
+<rectangle x1="52.47585" y1="69.31025" x2="52.62825" y2="69.32295" layer="21"/>
+<rectangle x1="53.02195" y1="69.31025" x2="53.16165" y2="69.32295" layer="21"/>
+<rectangle x1="53.21245" y1="69.31025" x2="53.45375" y2="69.32295" layer="21"/>
+<rectangle x1="54.24115" y1="69.31025" x2="54.48245" y2="69.32295" layer="21"/>
+<rectangle x1="54.73645" y1="69.31025" x2="54.97775" y2="69.32295" layer="21"/>
+<rectangle x1="50.62165" y1="69.32295" x2="50.86295" y2="69.33565" layer="21"/>
+<rectangle x1="51.11695" y1="69.32295" x2="51.34555" y2="69.33565" layer="21"/>
+<rectangle x1="52.12025" y1="69.32295" x2="52.36155" y2="69.33565" layer="21"/>
+<rectangle x1="52.48855" y1="69.32295" x2="52.62825" y2="69.33565" layer="21"/>
+<rectangle x1="53.02195" y1="69.32295" x2="53.16165" y2="69.33565" layer="21"/>
+<rectangle x1="53.21245" y1="69.32295" x2="53.45375" y2="69.33565" layer="21"/>
+<rectangle x1="54.24115" y1="69.32295" x2="54.48245" y2="69.33565" layer="21"/>
+<rectangle x1="54.73645" y1="69.32295" x2="54.99045" y2="69.33565" layer="21"/>
+<rectangle x1="50.60895" y1="69.33565" x2="50.86295" y2="69.34835" layer="21"/>
+<rectangle x1="51.11695" y1="69.33565" x2="51.34555" y2="69.34835" layer="21"/>
+<rectangle x1="52.13295" y1="69.33565" x2="52.36155" y2="69.34835" layer="21"/>
+<rectangle x1="52.48855" y1="69.33565" x2="52.62825" y2="69.34835" layer="21"/>
+<rectangle x1="53.02195" y1="69.33565" x2="53.17435" y2="69.34835" layer="21"/>
+<rectangle x1="53.21245" y1="69.33565" x2="53.44105" y2="69.34835" layer="21"/>
+<rectangle x1="54.24115" y1="69.33565" x2="54.48245" y2="69.34835" layer="21"/>
+<rectangle x1="54.74915" y1="69.33565" x2="54.99045" y2="69.34835" layer="21"/>
+<rectangle x1="50.60895" y1="69.34835" x2="50.85025" y2="69.36105" layer="21"/>
+<rectangle x1="51.10425" y1="69.34835" x2="51.34555" y2="69.36105" layer="21"/>
+<rectangle x1="52.13295" y1="69.34835" x2="52.36155" y2="69.36105" layer="21"/>
+<rectangle x1="52.48855" y1="69.34835" x2="52.64095" y2="69.36105" layer="21"/>
+<rectangle x1="53.02195" y1="69.34835" x2="53.17435" y2="69.36105" layer="21"/>
+<rectangle x1="53.19975" y1="69.34835" x2="53.44105" y2="69.36105" layer="21"/>
+<rectangle x1="54.25385" y1="69.34835" x2="54.48245" y2="69.36105" layer="21"/>
+<rectangle x1="54.74915" y1="69.34835" x2="55.00315" y2="69.36105" layer="21"/>
+<rectangle x1="50.59625" y1="69.36105" x2="50.85025" y2="69.37375" layer="21"/>
+<rectangle x1="51.10425" y1="69.36105" x2="51.34555" y2="69.37375" layer="21"/>
+<rectangle x1="52.13295" y1="69.36105" x2="52.36155" y2="69.37375" layer="21"/>
+<rectangle x1="52.48855" y1="69.36105" x2="52.64095" y2="69.37375" layer="21"/>
+<rectangle x1="53.02195" y1="69.36105" x2="53.17435" y2="69.37375" layer="21"/>
+<rectangle x1="53.19975" y1="69.36105" x2="53.44105" y2="69.37375" layer="21"/>
+<rectangle x1="54.25385" y1="69.36105" x2="54.48245" y2="69.37375" layer="21"/>
+<rectangle x1="54.76185" y1="69.36105" x2="55.00315" y2="69.37375" layer="21"/>
+<rectangle x1="50.59625" y1="69.37375" x2="50.83755" y2="69.38645" layer="21"/>
+<rectangle x1="51.10425" y1="69.37375" x2="51.33285" y2="69.38645" layer="21"/>
+<rectangle x1="52.13295" y1="69.37375" x2="52.36155" y2="69.38645" layer="21"/>
+<rectangle x1="52.50125" y1="69.37375" x2="52.64095" y2="69.38645" layer="21"/>
+<rectangle x1="53.03465" y1="69.37375" x2="53.17435" y2="69.38645" layer="21"/>
+<rectangle x1="53.19975" y1="69.37375" x2="53.44105" y2="69.38645" layer="21"/>
+<rectangle x1="54.25385" y1="69.37375" x2="54.48245" y2="69.38645" layer="21"/>
+<rectangle x1="54.76185" y1="69.37375" x2="55.00315" y2="69.38645" layer="21"/>
+<rectangle x1="50.59625" y1="69.38645" x2="50.83755" y2="69.39915" layer="21"/>
+<rectangle x1="51.10425" y1="69.38645" x2="51.33285" y2="69.39915" layer="21"/>
+<rectangle x1="52.13295" y1="69.38645" x2="52.36155" y2="69.39915" layer="21"/>
+<rectangle x1="52.50125" y1="69.38645" x2="52.64095" y2="69.39915" layer="21"/>
+<rectangle x1="53.03465" y1="69.38645" x2="53.17435" y2="69.39915" layer="21"/>
+<rectangle x1="53.19975" y1="69.38645" x2="53.44105" y2="69.39915" layer="21"/>
+<rectangle x1="54.25385" y1="69.38645" x2="54.48245" y2="69.39915" layer="21"/>
+<rectangle x1="54.76185" y1="69.38645" x2="55.00315" y2="69.39915" layer="21"/>
+<rectangle x1="50.58355" y1="69.39915" x2="50.83755" y2="69.41185" layer="21"/>
+<rectangle x1="51.10425" y1="69.39915" x2="51.33285" y2="69.41185" layer="21"/>
+<rectangle x1="52.13295" y1="69.39915" x2="52.36155" y2="69.41185" layer="21"/>
+<rectangle x1="52.50125" y1="69.39915" x2="52.65365" y2="69.41185" layer="21"/>
+<rectangle x1="53.03465" y1="69.39915" x2="53.18705" y2="69.41185" layer="21"/>
+<rectangle x1="53.19975" y1="69.39915" x2="53.42835" y2="69.41185" layer="21"/>
+<rectangle x1="54.25385" y1="69.39915" x2="54.48245" y2="69.41185" layer="21"/>
+<rectangle x1="54.77455" y1="69.39915" x2="55.01585" y2="69.41185" layer="21"/>
+<rectangle x1="50.58355" y1="69.41185" x2="50.82485" y2="69.42455" layer="21"/>
+<rectangle x1="51.10425" y1="69.41185" x2="51.33285" y2="69.42455" layer="21"/>
+<rectangle x1="52.13295" y1="69.41185" x2="52.36155" y2="69.42455" layer="21"/>
+<rectangle x1="52.50125" y1="69.41185" x2="52.65365" y2="69.42455" layer="21"/>
+<rectangle x1="53.03465" y1="69.41185" x2="53.18705" y2="69.42455" layer="21"/>
+<rectangle x1="53.19975" y1="69.41185" x2="53.42835" y2="69.42455" layer="21"/>
+<rectangle x1="54.25385" y1="69.41185" x2="54.48245" y2="69.42455" layer="21"/>
+<rectangle x1="54.77455" y1="69.41185" x2="55.01585" y2="69.42455" layer="21"/>
+<rectangle x1="50.58355" y1="69.42455" x2="50.82485" y2="69.43725" layer="21"/>
+<rectangle x1="51.10425" y1="69.42455" x2="51.33285" y2="69.43725" layer="21"/>
+<rectangle x1="52.13295" y1="69.42455" x2="52.37425" y2="69.43725" layer="21"/>
+<rectangle x1="52.51395" y1="69.42455" x2="52.65365" y2="69.43725" layer="21"/>
+<rectangle x1="53.04735" y1="69.42455" x2="53.42835" y2="69.43725" layer="21"/>
+<rectangle x1="54.25385" y1="69.42455" x2="54.48245" y2="69.43725" layer="21"/>
+<rectangle x1="54.77455" y1="69.42455" x2="55.01585" y2="69.43725" layer="21"/>
+<rectangle x1="50.57085" y1="69.43725" x2="50.81215" y2="69.44995" layer="21"/>
+<rectangle x1="51.10425" y1="69.43725" x2="51.33285" y2="69.44995" layer="21"/>
+<rectangle x1="52.14565" y1="69.43725" x2="52.37425" y2="69.44995" layer="21"/>
+<rectangle x1="52.51395" y1="69.43725" x2="52.66635" y2="69.44995" layer="21"/>
+<rectangle x1="53.04735" y1="69.43725" x2="53.42835" y2="69.44995" layer="21"/>
+<rectangle x1="54.25385" y1="69.43725" x2="54.48245" y2="69.44995" layer="21"/>
+<rectangle x1="54.78725" y1="69.43725" x2="55.02855" y2="69.44995" layer="21"/>
+<rectangle x1="50.57085" y1="69.44995" x2="50.81215" y2="69.46265" layer="21"/>
+<rectangle x1="51.10425" y1="69.44995" x2="51.33285" y2="69.46265" layer="21"/>
+<rectangle x1="52.14565" y1="69.44995" x2="52.37425" y2="69.46265" layer="21"/>
+<rectangle x1="52.51395" y1="69.44995" x2="52.66635" y2="69.46265" layer="21"/>
+<rectangle x1="53.04735" y1="69.44995" x2="53.41565" y2="69.46265" layer="21"/>
+<rectangle x1="54.26655" y1="69.44995" x2="54.48245" y2="69.46265" layer="21"/>
+<rectangle x1="54.78725" y1="69.44995" x2="55.02855" y2="69.46265" layer="21"/>
+<rectangle x1="50.55815" y1="69.46265" x2="50.81215" y2="69.47535" layer="21"/>
+<rectangle x1="51.10425" y1="69.46265" x2="51.33285" y2="69.47535" layer="21"/>
+<rectangle x1="52.14565" y1="69.46265" x2="52.37425" y2="69.47535" layer="21"/>
+<rectangle x1="52.52665" y1="69.46265" x2="52.66635" y2="69.47535" layer="21"/>
+<rectangle x1="53.06005" y1="69.46265" x2="53.41565" y2="69.47535" layer="21"/>
+<rectangle x1="54.26655" y1="69.46265" x2="54.48245" y2="69.47535" layer="21"/>
+<rectangle x1="54.78725" y1="69.46265" x2="55.02855" y2="69.47535" layer="21"/>
+<rectangle x1="50.55815" y1="69.47535" x2="50.79945" y2="69.48805" layer="21"/>
+<rectangle x1="51.10425" y1="69.47535" x2="51.33285" y2="69.48805" layer="21"/>
+<rectangle x1="52.14565" y1="69.47535" x2="52.37425" y2="69.48805" layer="21"/>
+<rectangle x1="52.52665" y1="69.47535" x2="52.66635" y2="69.48805" layer="21"/>
+<rectangle x1="53.06005" y1="69.47535" x2="53.41565" y2="69.48805" layer="21"/>
+<rectangle x1="54.26655" y1="69.47535" x2="54.48245" y2="69.48805" layer="21"/>
+<rectangle x1="54.79995" y1="69.47535" x2="55.04125" y2="69.48805" layer="21"/>
+<rectangle x1="50.55815" y1="69.48805" x2="50.79945" y2="69.50075" layer="21"/>
+<rectangle x1="51.10425" y1="69.48805" x2="51.33285" y2="69.50075" layer="21"/>
+<rectangle x1="52.14565" y1="69.48805" x2="52.38695" y2="69.50075" layer="21"/>
+<rectangle x1="52.52665" y1="69.48805" x2="52.67905" y2="69.50075" layer="21"/>
+<rectangle x1="53.06005" y1="69.48805" x2="53.40295" y2="69.50075" layer="21"/>
+<rectangle x1="54.26655" y1="69.48805" x2="54.48245" y2="69.50075" layer="21"/>
+<rectangle x1="54.79995" y1="69.48805" x2="55.04125" y2="69.50075" layer="21"/>
+<rectangle x1="50.55815" y1="69.50075" x2="50.79945" y2="69.51345" layer="21"/>
+<rectangle x1="51.10425" y1="69.50075" x2="51.33285" y2="69.51345" layer="21"/>
+<rectangle x1="52.14565" y1="69.50075" x2="52.38695" y2="69.51345" layer="21"/>
+<rectangle x1="52.52665" y1="69.50075" x2="52.67905" y2="69.51345" layer="21"/>
+<rectangle x1="53.06005" y1="69.50075" x2="53.40295" y2="69.51345" layer="21"/>
+<rectangle x1="54.26655" y1="69.50075" x2="54.48245" y2="69.51345" layer="21"/>
+<rectangle x1="54.81265" y1="69.50075" x2="55.04125" y2="69.51345" layer="21"/>
+<rectangle x1="50.54545" y1="69.51345" x2="50.78675" y2="69.52615" layer="21"/>
+<rectangle x1="51.10425" y1="69.51345" x2="51.33285" y2="69.52615" layer="21"/>
+<rectangle x1="52.15835" y1="69.51345" x2="52.39965" y2="69.52615" layer="21"/>
+<rectangle x1="52.53935" y1="69.51345" x2="52.67905" y2="69.52615" layer="21"/>
+<rectangle x1="53.07275" y1="69.51345" x2="53.39025" y2="69.52615" layer="21"/>
+<rectangle x1="54.26655" y1="69.51345" x2="54.48245" y2="69.52615" layer="21"/>
+<rectangle x1="54.81265" y1="69.51345" x2="55.05395" y2="69.52615" layer="21"/>
+<rectangle x1="50.54545" y1="69.52615" x2="50.78675" y2="69.53885" layer="21"/>
+<rectangle x1="51.10425" y1="69.52615" x2="51.33285" y2="69.53885" layer="21"/>
+<rectangle x1="52.15835" y1="69.52615" x2="52.39965" y2="69.53885" layer="21"/>
+<rectangle x1="52.53935" y1="69.52615" x2="52.67905" y2="69.53885" layer="21"/>
+<rectangle x1="53.07275" y1="69.52615" x2="53.39025" y2="69.53885" layer="21"/>
+<rectangle x1="54.26655" y1="69.52615" x2="54.48245" y2="69.53885" layer="21"/>
+<rectangle x1="54.81265" y1="69.52615" x2="55.05395" y2="69.53885" layer="21"/>
+<rectangle x1="50.54545" y1="69.53885" x2="50.78675" y2="69.55155" layer="21"/>
+<rectangle x1="51.10425" y1="69.53885" x2="51.33285" y2="69.55155" layer="21"/>
+<rectangle x1="52.15835" y1="69.53885" x2="52.39965" y2="69.55155" layer="21"/>
+<rectangle x1="52.53935" y1="69.53885" x2="52.69175" y2="69.55155" layer="21"/>
+<rectangle x1="53.07275" y1="69.53885" x2="53.39025" y2="69.55155" layer="21"/>
+<rectangle x1="54.26655" y1="69.53885" x2="54.48245" y2="69.55155" layer="21"/>
+<rectangle x1="54.81265" y1="69.53885" x2="55.05395" y2="69.55155" layer="21"/>
+<rectangle x1="50.54545" y1="69.55155" x2="50.77405" y2="69.56425" layer="21"/>
+<rectangle x1="51.10425" y1="69.55155" x2="51.33285" y2="69.56425" layer="21"/>
+<rectangle x1="52.17105" y1="69.55155" x2="52.39965" y2="69.56425" layer="21"/>
+<rectangle x1="52.53935" y1="69.55155" x2="52.69175" y2="69.56425" layer="21"/>
+<rectangle x1="53.07275" y1="69.55155" x2="53.39025" y2="69.56425" layer="21"/>
+<rectangle x1="54.26655" y1="69.55155" x2="54.48245" y2="69.56425" layer="21"/>
+<rectangle x1="54.82535" y1="69.55155" x2="55.06665" y2="69.56425" layer="21"/>
+<rectangle x1="50.53275" y1="69.56425" x2="50.77405" y2="69.57695" layer="21"/>
+<rectangle x1="51.10425" y1="69.56425" x2="51.33285" y2="69.57695" layer="21"/>
+<rectangle x1="52.17105" y1="69.56425" x2="52.41235" y2="69.57695" layer="21"/>
+<rectangle x1="52.55205" y1="69.56425" x2="52.69175" y2="69.57695" layer="21"/>
+<rectangle x1="53.08545" y1="69.56425" x2="53.39025" y2="69.57695" layer="21"/>
+<rectangle x1="54.25385" y1="69.56425" x2="54.48245" y2="69.57695" layer="21"/>
+<rectangle x1="54.82535" y1="69.56425" x2="55.06665" y2="69.57695" layer="21"/>
+<rectangle x1="50.53275" y1="69.57695" x2="50.77405" y2="69.58965" layer="21"/>
+<rectangle x1="51.10425" y1="69.57695" x2="51.33285" y2="69.58965" layer="21"/>
+<rectangle x1="52.17105" y1="69.57695" x2="52.41235" y2="69.58965" layer="21"/>
+<rectangle x1="52.55205" y1="69.57695" x2="52.69175" y2="69.58965" layer="21"/>
+<rectangle x1="53.08545" y1="69.57695" x2="53.37755" y2="69.58965" layer="21"/>
+<rectangle x1="54.25385" y1="69.57695" x2="54.48245" y2="69.58965" layer="21"/>
+<rectangle x1="54.82535" y1="69.57695" x2="55.06665" y2="69.58965" layer="21"/>
+<rectangle x1="50.53275" y1="69.58965" x2="50.77405" y2="69.60235" layer="21"/>
+<rectangle x1="51.10425" y1="69.58965" x2="51.33285" y2="69.60235" layer="21"/>
+<rectangle x1="52.18375" y1="69.58965" x2="52.41235" y2="69.60235" layer="21"/>
+<rectangle x1="52.55205" y1="69.58965" x2="52.70445" y2="69.60235" layer="21"/>
+<rectangle x1="53.08545" y1="69.58965" x2="53.37755" y2="69.60235" layer="21"/>
+<rectangle x1="54.25385" y1="69.58965" x2="54.48245" y2="69.60235" layer="21"/>
+<rectangle x1="54.83805" y1="69.58965" x2="55.06665" y2="69.60235" layer="21"/>
+<rectangle x1="50.53275" y1="69.60235" x2="50.76135" y2="69.61505" layer="21"/>
+<rectangle x1="51.10425" y1="69.60235" x2="51.34555" y2="69.61505" layer="21"/>
+<rectangle x1="52.18375" y1="69.60235" x2="52.42505" y2="69.61505" layer="21"/>
+<rectangle x1="52.56475" y1="69.60235" x2="52.70445" y2="69.61505" layer="21"/>
+<rectangle x1="53.09815" y1="69.60235" x2="53.37755" y2="69.61505" layer="21"/>
+<rectangle x1="54.25385" y1="69.60235" x2="54.48245" y2="69.61505" layer="21"/>
+<rectangle x1="54.83805" y1="69.60235" x2="55.07935" y2="69.61505" layer="21"/>
+<rectangle x1="50.52005" y1="69.61505" x2="50.76135" y2="69.62775" layer="21"/>
+<rectangle x1="51.10425" y1="69.61505" x2="51.34555" y2="69.62775" layer="21"/>
+<rectangle x1="52.18375" y1="69.61505" x2="52.42505" y2="69.62775" layer="21"/>
+<rectangle x1="52.56475" y1="69.61505" x2="52.70445" y2="69.62775" layer="21"/>
+<rectangle x1="53.09815" y1="69.61505" x2="53.37755" y2="69.62775" layer="21"/>
+<rectangle x1="54.25385" y1="69.61505" x2="54.48245" y2="69.62775" layer="21"/>
+<rectangle x1="54.85075" y1="69.61505" x2="55.07935" y2="69.62775" layer="21"/>
+<rectangle x1="50.52005" y1="69.62775" x2="50.74865" y2="69.64045" layer="21"/>
+<rectangle x1="51.10425" y1="69.62775" x2="51.34555" y2="69.64045" layer="21"/>
+<rectangle x1="52.19645" y1="69.62775" x2="52.43775" y2="69.64045" layer="21"/>
+<rectangle x1="52.56475" y1="69.62775" x2="52.71715" y2="69.64045" layer="21"/>
+<rectangle x1="53.09815" y1="69.62775" x2="53.39025" y2="69.64045" layer="21"/>
+<rectangle x1="54.25385" y1="69.62775" x2="54.48245" y2="69.64045" layer="21"/>
+<rectangle x1="54.85075" y1="69.62775" x2="55.07935" y2="69.64045" layer="21"/>
+<rectangle x1="50.52005" y1="69.64045" x2="50.74865" y2="69.65315" layer="21"/>
+<rectangle x1="51.11695" y1="69.64045" x2="51.34555" y2="69.65315" layer="21"/>
+<rectangle x1="52.19645" y1="69.64045" x2="52.43775" y2="69.65315" layer="21"/>
+<rectangle x1="52.56475" y1="69.64045" x2="52.71715" y2="69.65315" layer="21"/>
+<rectangle x1="53.09815" y1="69.64045" x2="53.39025" y2="69.65315" layer="21"/>
+<rectangle x1="54.25385" y1="69.64045" x2="54.48245" y2="69.65315" layer="21"/>
+<rectangle x1="54.85075" y1="69.64045" x2="55.07935" y2="69.65315" layer="21"/>
+<rectangle x1="50.52005" y1="69.65315" x2="50.74865" y2="69.66585" layer="21"/>
+<rectangle x1="51.11695" y1="69.65315" x2="51.34555" y2="69.66585" layer="21"/>
+<rectangle x1="52.20915" y1="69.65315" x2="52.45045" y2="69.66585" layer="21"/>
+<rectangle x1="52.57745" y1="69.65315" x2="52.71715" y2="69.66585" layer="21"/>
+<rectangle x1="53.11085" y1="69.65315" x2="53.39025" y2="69.66585" layer="21"/>
+<rectangle x1="54.25385" y1="69.65315" x2="54.46975" y2="69.66585" layer="21"/>
+<rectangle x1="54.85075" y1="69.65315" x2="55.07935" y2="69.66585" layer="21"/>
+<rectangle x1="50.52005" y1="69.66585" x2="50.74865" y2="69.67855" layer="21"/>
+<rectangle x1="51.11695" y1="69.66585" x2="51.34555" y2="69.67855" layer="21"/>
+<rectangle x1="52.20915" y1="69.66585" x2="52.46315" y2="69.67855" layer="21"/>
+<rectangle x1="52.57745" y1="69.66585" x2="52.71715" y2="69.67855" layer="21"/>
+<rectangle x1="53.11085" y1="69.66585" x2="53.39025" y2="69.67855" layer="21"/>
+<rectangle x1="54.24115" y1="69.66585" x2="54.46975" y2="69.67855" layer="21"/>
+<rectangle x1="54.85075" y1="69.66585" x2="55.09205" y2="69.67855" layer="21"/>
+<rectangle x1="50.50735" y1="69.67855" x2="50.74865" y2="69.69125" layer="21"/>
+<rectangle x1="51.11695" y1="69.67855" x2="51.35825" y2="69.69125" layer="21"/>
+<rectangle x1="52.20915" y1="69.67855" x2="52.46315" y2="69.69125" layer="21"/>
+<rectangle x1="52.57745" y1="69.67855" x2="52.72985" y2="69.69125" layer="21"/>
+<rectangle x1="53.11085" y1="69.67855" x2="53.40295" y2="69.69125" layer="21"/>
+<rectangle x1="54.24115" y1="69.67855" x2="54.46975" y2="69.69125" layer="21"/>
+<rectangle x1="54.86345" y1="69.67855" x2="55.09205" y2="69.69125" layer="21"/>
+<rectangle x1="50.50735" y1="69.69125" x2="50.73595" y2="69.70395" layer="21"/>
+<rectangle x1="51.11695" y1="69.69125" x2="51.35825" y2="69.70395" layer="21"/>
+<rectangle x1="52.20915" y1="69.69125" x2="52.46315" y2="69.70395" layer="21"/>
+<rectangle x1="52.57745" y1="69.69125" x2="52.72985" y2="69.70395" layer="21"/>
+<rectangle x1="53.11085" y1="69.69125" x2="53.40295" y2="69.70395" layer="21"/>
+<rectangle x1="54.24115" y1="69.69125" x2="54.46975" y2="69.70395" layer="21"/>
+<rectangle x1="54.86345" y1="69.69125" x2="55.09205" y2="69.70395" layer="21"/>
+<rectangle x1="50.50735" y1="69.70395" x2="50.73595" y2="69.71665" layer="21"/>
+<rectangle x1="51.11695" y1="69.70395" x2="51.35825" y2="69.71665" layer="21"/>
+<rectangle x1="52.19645" y1="69.70395" x2="52.47585" y2="69.71665" layer="21"/>
+<rectangle x1="52.57745" y1="69.70395" x2="52.72985" y2="69.71665" layer="21"/>
+<rectangle x1="53.12355" y1="69.70395" x2="53.41565" y2="69.71665" layer="21"/>
+<rectangle x1="54.24115" y1="69.70395" x2="54.46975" y2="69.71665" layer="21"/>
+<rectangle x1="54.86345" y1="69.70395" x2="55.09205" y2="69.71665" layer="21"/>
+<rectangle x1="50.49465" y1="69.71665" x2="50.73595" y2="69.72935" layer="21"/>
+<rectangle x1="51.12965" y1="69.71665" x2="51.35825" y2="69.72935" layer="21"/>
+<rectangle x1="52.18375" y1="69.71665" x2="52.48855" y2="69.72935" layer="21"/>
+<rectangle x1="52.59015" y1="69.71665" x2="52.72985" y2="69.72935" layer="21"/>
+<rectangle x1="53.12355" y1="69.71665" x2="53.41565" y2="69.72935" layer="21"/>
+<rectangle x1="54.24115" y1="69.71665" x2="54.46975" y2="69.72935" layer="21"/>
+<rectangle x1="54.86345" y1="69.71665" x2="55.09205" y2="69.72935" layer="21"/>
+<rectangle x1="50.49465" y1="69.72935" x2="50.73595" y2="69.74205" layer="21"/>
+<rectangle x1="51.12965" y1="69.72935" x2="51.35825" y2="69.74205" layer="21"/>
+<rectangle x1="52.18375" y1="69.72935" x2="52.48855" y2="69.74205" layer="21"/>
+<rectangle x1="52.59015" y1="69.72935" x2="52.72985" y2="69.74205" layer="21"/>
+<rectangle x1="53.12355" y1="69.72935" x2="53.42835" y2="69.74205" layer="21"/>
+<rectangle x1="54.24115" y1="69.72935" x2="54.46975" y2="69.74205" layer="21"/>
+<rectangle x1="54.87615" y1="69.72935" x2="55.10475" y2="69.74205" layer="21"/>
+<rectangle x1="50.49465" y1="69.74205" x2="50.73595" y2="69.75475" layer="21"/>
+<rectangle x1="51.12965" y1="69.74205" x2="51.35825" y2="69.75475" layer="21"/>
+<rectangle x1="52.17105" y1="69.74205" x2="52.50125" y2="69.75475" layer="21"/>
+<rectangle x1="52.59015" y1="69.74205" x2="52.74255" y2="69.75475" layer="21"/>
+<rectangle x1="53.12355" y1="69.74205" x2="53.42835" y2="69.75475" layer="21"/>
+<rectangle x1="54.22845" y1="69.74205" x2="54.46975" y2="69.75475" layer="21"/>
+<rectangle x1="54.87615" y1="69.74205" x2="55.10475" y2="69.75475" layer="21"/>
+<rectangle x1="50.49465" y1="69.75475" x2="50.72325" y2="69.76745" layer="21"/>
+<rectangle x1="51.12965" y1="69.75475" x2="51.35825" y2="69.76745" layer="21"/>
+<rectangle x1="52.15835" y1="69.75475" x2="52.51395" y2="69.76745" layer="21"/>
+<rectangle x1="52.59015" y1="69.75475" x2="52.74255" y2="69.76745" layer="21"/>
+<rectangle x1="53.13625" y1="69.75475" x2="53.44105" y2="69.76745" layer="21"/>
+<rectangle x1="54.22845" y1="69.75475" x2="54.46975" y2="69.76745" layer="21"/>
+<rectangle x1="54.87615" y1="69.75475" x2="55.10475" y2="69.76745" layer="21"/>
+<rectangle x1="50.49465" y1="69.76745" x2="50.72325" y2="69.78015" layer="21"/>
+<rectangle x1="51.12965" y1="69.76745" x2="51.37095" y2="69.78015" layer="21"/>
+<rectangle x1="52.14565" y1="69.76745" x2="52.52665" y2="69.78015" layer="21"/>
+<rectangle x1="52.60285" y1="69.76745" x2="52.75525" y2="69.78015" layer="21"/>
+<rectangle x1="53.13625" y1="69.76745" x2="53.45375" y2="69.78015" layer="21"/>
+<rectangle x1="54.22845" y1="69.76745" x2="54.45705" y2="69.78015" layer="21"/>
+<rectangle x1="54.87615" y1="69.76745" x2="55.11745" y2="69.78015" layer="21"/>
+<rectangle x1="50.49465" y1="69.78015" x2="50.72325" y2="69.79285" layer="21"/>
+<rectangle x1="51.12965" y1="69.78015" x2="51.37095" y2="69.79285" layer="21"/>
+<rectangle x1="52.13295" y1="69.78015" x2="52.52665" y2="69.79285" layer="21"/>
+<rectangle x1="52.60285" y1="69.78015" x2="52.75525" y2="69.79285" layer="21"/>
+<rectangle x1="53.13625" y1="69.78015" x2="53.46645" y2="69.79285" layer="21"/>
+<rectangle x1="54.22845" y1="69.78015" x2="54.45705" y2="69.79285" layer="21"/>
+<rectangle x1="54.87615" y1="69.78015" x2="55.11745" y2="69.79285" layer="21"/>
+<rectangle x1="50.48195" y1="69.79285" x2="50.72325" y2="69.80555" layer="21"/>
+<rectangle x1="51.14235" y1="69.79285" x2="51.37095" y2="69.80555" layer="21"/>
+<rectangle x1="52.13295" y1="69.79285" x2="52.53935" y2="69.80555" layer="21"/>
+<rectangle x1="52.60285" y1="69.79285" x2="52.75525" y2="69.80555" layer="21"/>
+<rectangle x1="53.13625" y1="69.79285" x2="53.46645" y2="69.80555" layer="21"/>
+<rectangle x1="54.21575" y1="69.79285" x2="54.45705" y2="69.80555" layer="21"/>
+<rectangle x1="54.88885" y1="69.79285" x2="55.11745" y2="69.80555" layer="21"/>
+<rectangle x1="50.48195" y1="69.80555" x2="50.72325" y2="69.81825" layer="21"/>
+<rectangle x1="51.14235" y1="69.80555" x2="51.37095" y2="69.81825" layer="21"/>
+<rectangle x1="52.12025" y1="69.80555" x2="52.55205" y2="69.81825" layer="21"/>
+<rectangle x1="52.61555" y1="69.80555" x2="52.75525" y2="69.81825" layer="21"/>
+<rectangle x1="53.14895" y1="69.80555" x2="53.47915" y2="69.81825" layer="21"/>
+<rectangle x1="54.21575" y1="69.80555" x2="54.45705" y2="69.81825" layer="21"/>
+<rectangle x1="54.88885" y1="69.80555" x2="55.11745" y2="69.81825" layer="21"/>
+<rectangle x1="50.48195" y1="69.81825" x2="50.71055" y2="69.83095" layer="21"/>
+<rectangle x1="51.14235" y1="69.81825" x2="51.38365" y2="69.83095" layer="21"/>
+<rectangle x1="52.10755" y1="69.81825" x2="52.56475" y2="69.83095" layer="21"/>
+<rectangle x1="52.61555" y1="69.81825" x2="52.76795" y2="69.83095" layer="21"/>
+<rectangle x1="53.14895" y1="69.81825" x2="53.49185" y2="69.83095" layer="21"/>
+<rectangle x1="54.21575" y1="69.81825" x2="54.45705" y2="69.83095" layer="21"/>
+<rectangle x1="54.88885" y1="69.81825" x2="55.11745" y2="69.83095" layer="21"/>
+<rectangle x1="50.48195" y1="69.83095" x2="50.71055" y2="69.84365" layer="21"/>
+<rectangle x1="51.14235" y1="69.83095" x2="51.38365" y2="69.84365" layer="21"/>
+<rectangle x1="52.09485" y1="69.83095" x2="52.57745" y2="69.84365" layer="21"/>
+<rectangle x1="52.60285" y1="69.83095" x2="52.76795" y2="69.84365" layer="21"/>
+<rectangle x1="53.14895" y1="69.83095" x2="53.51725" y2="69.84365" layer="21"/>
+<rectangle x1="54.21575" y1="69.83095" x2="54.44435" y2="69.84365" layer="21"/>
+<rectangle x1="54.88885" y1="69.83095" x2="55.11745" y2="69.84365" layer="21"/>
+<rectangle x1="50.48195" y1="69.84365" x2="50.71055" y2="69.85635" layer="21"/>
+<rectangle x1="51.14235" y1="69.84365" x2="51.38365" y2="69.85635" layer="21"/>
+<rectangle x1="52.08215" y1="69.84365" x2="52.57745" y2="69.85635" layer="21"/>
+<rectangle x1="52.60285" y1="69.84365" x2="52.76795" y2="69.85635" layer="21"/>
+<rectangle x1="53.16165" y1="69.84365" x2="53.52995" y2="69.85635" layer="21"/>
+<rectangle x1="54.20305" y1="69.84365" x2="54.44435" y2="69.85635" layer="21"/>
+<rectangle x1="54.90155" y1="69.84365" x2="55.13015" y2="69.85635" layer="21"/>
+<rectangle x1="50.48195" y1="69.85635" x2="50.71055" y2="69.86905" layer="21"/>
+<rectangle x1="51.15505" y1="69.85635" x2="51.38365" y2="69.86905" layer="21"/>
+<rectangle x1="52.06945" y1="69.85635" x2="52.76795" y2="69.86905" layer="21"/>
+<rectangle x1="53.16165" y1="69.85635" x2="53.54265" y2="69.86905" layer="21"/>
+<rectangle x1="54.20305" y1="69.85635" x2="54.44435" y2="69.86905" layer="21"/>
+<rectangle x1="54.90155" y1="69.85635" x2="55.13015" y2="69.86905" layer="21"/>
+<rectangle x1="50.46925" y1="69.86905" x2="50.69785" y2="69.88175" layer="21"/>
+<rectangle x1="51.15505" y1="69.86905" x2="51.39635" y2="69.88175" layer="21"/>
+<rectangle x1="52.05675" y1="69.86905" x2="52.75525" y2="69.88175" layer="21"/>
+<rectangle x1="53.16165" y1="69.86905" x2="53.55535" y2="69.88175" layer="21"/>
+<rectangle x1="54.19035" y1="69.86905" x2="54.43165" y2="69.88175" layer="21"/>
+<rectangle x1="54.90155" y1="69.86905" x2="55.13015" y2="69.88175" layer="21"/>
+<rectangle x1="50.46925" y1="69.88175" x2="50.69785" y2="69.89445" layer="21"/>
+<rectangle x1="51.15505" y1="69.88175" x2="51.39635" y2="69.89445" layer="21"/>
+<rectangle x1="52.04405" y1="69.88175" x2="52.74255" y2="69.89445" layer="21"/>
+<rectangle x1="53.19975" y1="69.88175" x2="53.56805" y2="69.89445" layer="21"/>
+<rectangle x1="54.19035" y1="69.88175" x2="54.43165" y2="69.89445" layer="21"/>
+<rectangle x1="54.90155" y1="69.88175" x2="55.13015" y2="69.89445" layer="21"/>
+<rectangle x1="50.46925" y1="69.89445" x2="50.69785" y2="69.90715" layer="21"/>
+<rectangle x1="51.16775" y1="69.89445" x2="51.39635" y2="69.90715" layer="21"/>
+<rectangle x1="52.03135" y1="69.89445" x2="52.72985" y2="69.90715" layer="21"/>
+<rectangle x1="53.27595" y1="69.89445" x2="53.58075" y2="69.90715" layer="21"/>
+<rectangle x1="54.19035" y1="69.89445" x2="54.43165" y2="69.90715" layer="21"/>
+<rectangle x1="54.90155" y1="69.89445" x2="55.13015" y2="69.90715" layer="21"/>
+<rectangle x1="50.46925" y1="69.90715" x2="50.69785" y2="69.91985" layer="21"/>
+<rectangle x1="51.16775" y1="69.90715" x2="51.40905" y2="69.91985" layer="21"/>
+<rectangle x1="52.00595" y1="69.90715" x2="52.72985" y2="69.91985" layer="21"/>
+<rectangle x1="53.33945" y1="69.90715" x2="53.60615" y2="69.91985" layer="21"/>
+<rectangle x1="54.17765" y1="69.90715" x2="54.43165" y2="69.91985" layer="21"/>
+<rectangle x1="54.90155" y1="69.90715" x2="55.13015" y2="69.91985" layer="21"/>
+<rectangle x1="50.46925" y1="69.91985" x2="50.69785" y2="69.93255" layer="21"/>
+<rectangle x1="51.16775" y1="69.91985" x2="51.40905" y2="69.93255" layer="21"/>
+<rectangle x1="51.99325" y1="69.91985" x2="52.32345" y2="69.93255" layer="21"/>
+<rectangle x1="52.36155" y1="69.91985" x2="52.71715" y2="69.93255" layer="21"/>
+<rectangle x1="53.36485" y1="69.91985" x2="53.61885" y2="69.93255" layer="21"/>
+<rectangle x1="54.17765" y1="69.91985" x2="54.41895" y2="69.93255" layer="21"/>
+<rectangle x1="54.90155" y1="69.91985" x2="55.13015" y2="69.93255" layer="21"/>
+<rectangle x1="50.46925" y1="69.93255" x2="50.69785" y2="69.94525" layer="21"/>
+<rectangle x1="51.16775" y1="69.93255" x2="51.42175" y2="69.94525" layer="21"/>
+<rectangle x1="51.98055" y1="69.93255" x2="52.31075" y2="69.94525" layer="21"/>
+<rectangle x1="52.36155" y1="69.93255" x2="52.71715" y2="69.94525" layer="21"/>
+<rectangle x1="53.37755" y1="69.93255" x2="53.63155" y2="69.94525" layer="21"/>
+<rectangle x1="54.17765" y1="69.93255" x2="54.41895" y2="69.94525" layer="21"/>
+<rectangle x1="54.91425" y1="69.93255" x2="55.13015" y2="69.94525" layer="21"/>
+<rectangle x1="50.46925" y1="69.94525" x2="50.69785" y2="69.95795" layer="21"/>
+<rectangle x1="51.18045" y1="69.94525" x2="51.42175" y2="69.95795" layer="21"/>
+<rectangle x1="51.95515" y1="69.94525" x2="52.29805" y2="69.95795" layer="21"/>
+<rectangle x1="52.37425" y1="69.94525" x2="52.70445" y2="69.95795" layer="21"/>
+<rectangle x1="53.39025" y1="69.94525" x2="53.65695" y2="69.95795" layer="21"/>
+<rectangle x1="54.16495" y1="69.94525" x2="54.44435" y2="69.95795" layer="21"/>
+<rectangle x1="54.91425" y1="69.94525" x2="55.14285" y2="69.95795" layer="21"/>
+<rectangle x1="50.46925" y1="69.95795" x2="50.69785" y2="69.97065" layer="21"/>
+<rectangle x1="51.16775" y1="69.95795" x2="51.43445" y2="69.97065" layer="21"/>
+<rectangle x1="51.94245" y1="69.95795" x2="52.28535" y2="69.97065" layer="21"/>
+<rectangle x1="52.38695" y1="69.95795" x2="52.70445" y2="69.97065" layer="21"/>
+<rectangle x1="53.41565" y1="69.95795" x2="53.68235" y2="69.97065" layer="21"/>
+<rectangle x1="54.16495" y1="69.95795" x2="54.48245" y2="69.97065" layer="21"/>
+<rectangle x1="54.91425" y1="69.95795" x2="55.14285" y2="69.97065" layer="21"/>
+<rectangle x1="50.45655" y1="69.97065" x2="50.68515" y2="69.98335" layer="21"/>
+<rectangle x1="51.12965" y1="69.97065" x2="51.43445" y2="69.98335" layer="21"/>
+<rectangle x1="51.91705" y1="69.97065" x2="52.27265" y2="69.98335" layer="21"/>
+<rectangle x1="52.39965" y1="69.97065" x2="52.70445" y2="69.98335" layer="21"/>
+<rectangle x1="53.42835" y1="69.97065" x2="53.69505" y2="69.98335" layer="21"/>
+<rectangle x1="54.15225" y1="69.97065" x2="54.50785" y2="69.98335" layer="21"/>
+<rectangle x1="54.91425" y1="69.97065" x2="55.14285" y2="69.98335" layer="21"/>
+<rectangle x1="50.45655" y1="69.98335" x2="50.68515" y2="69.99605" layer="21"/>
+<rectangle x1="51.10425" y1="69.98335" x2="51.44715" y2="69.99605" layer="21"/>
+<rectangle x1="51.89165" y1="69.98335" x2="52.25995" y2="69.99605" layer="21"/>
+<rectangle x1="52.41235" y1="69.98335" x2="52.70445" y2="69.99605" layer="21"/>
+<rectangle x1="53.42835" y1="69.98335" x2="53.73315" y2="69.99605" layer="21"/>
+<rectangle x1="54.15225" y1="69.98335" x2="54.55865" y2="69.99605" layer="21"/>
+<rectangle x1="54.91425" y1="69.98335" x2="55.14285" y2="69.99605" layer="21"/>
+<rectangle x1="50.45655" y1="69.99605" x2="50.68515" y2="70.00875" layer="21"/>
+<rectangle x1="51.07885" y1="69.99605" x2="51.44715" y2="70.00875" layer="21"/>
+<rectangle x1="51.87895" y1="69.99605" x2="52.25995" y2="70.00875" layer="21"/>
+<rectangle x1="52.42505" y1="69.99605" x2="52.70445" y2="70.00875" layer="21"/>
+<rectangle x1="53.44105" y1="69.99605" x2="53.74585" y2="70.00875" layer="21"/>
+<rectangle x1="54.13955" y1="69.99605" x2="54.58405" y2="70.00875" layer="21"/>
+<rectangle x1="54.91425" y1="69.99605" x2="55.14285" y2="70.00875" layer="21"/>
+<rectangle x1="50.45655" y1="70.00875" x2="50.68515" y2="70.02145" layer="21"/>
+<rectangle x1="51.04075" y1="70.00875" x2="51.44715" y2="70.02145" layer="21"/>
+<rectangle x1="51.84085" y1="70.00875" x2="52.23455" y2="70.02145" layer="21"/>
+<rectangle x1="52.43775" y1="70.00875" x2="52.70445" y2="70.02145" layer="21"/>
+<rectangle x1="53.44105" y1="70.00875" x2="53.78395" y2="70.02145" layer="21"/>
+<rectangle x1="54.13955" y1="70.00875" x2="54.63485" y2="70.02145" layer="21"/>
+<rectangle x1="54.91425" y1="70.00875" x2="55.14285" y2="70.02145" layer="21"/>
+<rectangle x1="50.44385" y1="70.02145" x2="50.68515" y2="70.03415" layer="21"/>
+<rectangle x1="51.00265" y1="70.02145" x2="51.45985" y2="70.03415" layer="21"/>
+<rectangle x1="51.81545" y1="70.02145" x2="52.22185" y2="70.03415" layer="21"/>
+<rectangle x1="52.45045" y1="70.02145" x2="52.70445" y2="70.03415" layer="21"/>
+<rectangle x1="53.45375" y1="70.02145" x2="53.80935" y2="70.03415" layer="21"/>
+<rectangle x1="54.12685" y1="70.02145" x2="54.71105" y2="70.03415" layer="21"/>
+<rectangle x1="54.91425" y1="70.02145" x2="55.15555" y2="70.03415" layer="21"/>
+<rectangle x1="50.44385" y1="70.03415" x2="50.68515" y2="70.04685" layer="21"/>
+<rectangle x1="50.96455" y1="70.03415" x2="51.47255" y2="70.04685" layer="21"/>
+<rectangle x1="51.79005" y1="70.03415" x2="52.22185" y2="70.04685" layer="21"/>
+<rectangle x1="52.46315" y1="70.03415" x2="52.70445" y2="70.04685" layer="21"/>
+<rectangle x1="53.45375" y1="70.03415" x2="53.83475" y2="70.04685" layer="21"/>
+<rectangle x1="54.12685" y1="70.03415" x2="55.15555" y2="70.04685" layer="21"/>
+<rectangle x1="50.44385" y1="70.04685" x2="50.68515" y2="70.05955" layer="21"/>
+<rectangle x1="50.90105" y1="70.04685" x2="51.47255" y2="70.05955" layer="21"/>
+<rectangle x1="51.76465" y1="70.04685" x2="52.19645" y2="70.05955" layer="21"/>
+<rectangle x1="52.47585" y1="70.04685" x2="52.70445" y2="70.05955" layer="21"/>
+<rectangle x1="53.45375" y1="70.04685" x2="53.87285" y2="70.05955" layer="21"/>
+<rectangle x1="54.11415" y1="70.04685" x2="55.15555" y2="70.05955" layer="21"/>
+<rectangle x1="50.44385" y1="70.05955" x2="51.48525" y2="70.07225" layer="21"/>
+<rectangle x1="51.72655" y1="70.05955" x2="52.18375" y2="70.07225" layer="21"/>
+<rectangle x1="52.48855" y1="70.05955" x2="52.71715" y2="70.07225" layer="21"/>
+<rectangle x1="53.46645" y1="70.05955" x2="53.91095" y2="70.07225" layer="21"/>
+<rectangle x1="54.11415" y1="70.05955" x2="55.15555" y2="70.07225" layer="21"/>
+<rectangle x1="50.44385" y1="70.07225" x2="51.49795" y2="70.08495" layer="21"/>
+<rectangle x1="51.68845" y1="70.07225" x2="52.17105" y2="70.08495" layer="21"/>
+<rectangle x1="52.50125" y1="70.07225" x2="52.71715" y2="70.08495" layer="21"/>
+<rectangle x1="53.46645" y1="70.07225" x2="53.96175" y2="70.08495" layer="21"/>
+<rectangle x1="54.10145" y1="70.07225" x2="55.15555" y2="70.08495" layer="21"/>
+<rectangle x1="50.44385" y1="70.08495" x2="51.49795" y2="70.09765" layer="21"/>
+<rectangle x1="51.65035" y1="70.08495" x2="52.15835" y2="70.09765" layer="21"/>
+<rectangle x1="52.50125" y1="70.08495" x2="52.71715" y2="70.09765" layer="21"/>
+<rectangle x1="53.46645" y1="70.08495" x2="53.99985" y2="70.09765" layer="21"/>
+<rectangle x1="54.08875" y1="70.08495" x2="55.15555" y2="70.09765" layer="21"/>
+<rectangle x1="50.44385" y1="70.09765" x2="51.51065" y2="70.11035" layer="21"/>
+<rectangle x1="51.59955" y1="70.09765" x2="52.13295" y2="70.11035" layer="21"/>
+<rectangle x1="52.52665" y1="70.09765" x2="52.72985" y2="70.11035" layer="21"/>
+<rectangle x1="53.46645" y1="70.09765" x2="54.05065" y2="70.11035" layer="21"/>
+<rectangle x1="54.07605" y1="70.09765" x2="55.15555" y2="70.11035" layer="21"/>
+<rectangle x1="50.44385" y1="70.11035" x2="52.12025" y2="70.12305" layer="21"/>
+<rectangle x1="52.53935" y1="70.11035" x2="52.74255" y2="70.12305" layer="21"/>
+<rectangle x1="53.46645" y1="70.11035" x2="55.15555" y2="70.12305" layer="21"/>
+<rectangle x1="50.44385" y1="70.12305" x2="52.09485" y2="70.13575" layer="21"/>
+<rectangle x1="52.56475" y1="70.12305" x2="52.75525" y2="70.13575" layer="21"/>
+<rectangle x1="53.46645" y1="70.12305" x2="55.15555" y2="70.13575" layer="21"/>
+<rectangle x1="50.44385" y1="70.13575" x2="52.08215" y2="70.14845" layer="21"/>
+<rectangle x1="52.56475" y1="70.13575" x2="52.75525" y2="70.14845" layer="21"/>
+<rectangle x1="53.46645" y1="70.13575" x2="55.15555" y2="70.14845" layer="21"/>
+<rectangle x1="50.44385" y1="70.14845" x2="52.06945" y2="70.16115" layer="21"/>
+<rectangle x1="52.59015" y1="70.14845" x2="52.76795" y2="70.16115" layer="21"/>
+<rectangle x1="53.45375" y1="70.14845" x2="55.14285" y2="70.16115" layer="21"/>
+<rectangle x1="50.45655" y1="70.16115" x2="52.05675" y2="70.17385" layer="21"/>
+<rectangle x1="52.60285" y1="70.16115" x2="52.79335" y2="70.17385" layer="21"/>
+<rectangle x1="53.45375" y1="70.16115" x2="54.31735" y2="70.17385" layer="21"/>
+<rectangle x1="54.36815" y1="70.16115" x2="55.14285" y2="70.17385" layer="21"/>
+<rectangle x1="50.45655" y1="70.17385" x2="51.24395" y2="70.18655" layer="21"/>
+<rectangle x1="51.28205" y1="70.17385" x2="52.05675" y2="70.18655" layer="21"/>
+<rectangle x1="52.61555" y1="70.17385" x2="52.81875" y2="70.18655" layer="21"/>
+<rectangle x1="53.45375" y1="70.17385" x2="54.31735" y2="70.18655" layer="21"/>
+<rectangle x1="54.36815" y1="70.17385" x2="55.13015" y2="70.18655" layer="21"/>
+<rectangle x1="50.45655" y1="70.18655" x2="51.23125" y2="70.19925" layer="21"/>
+<rectangle x1="51.29475" y1="70.18655" x2="52.05675" y2="70.19925" layer="21"/>
+<rectangle x1="52.61555" y1="70.18655" x2="52.83145" y2="70.19925" layer="21"/>
+<rectangle x1="53.44105" y1="70.18655" x2="54.30465" y2="70.19925" layer="21"/>
+<rectangle x1="54.36815" y1="70.18655" x2="55.13015" y2="70.19925" layer="21"/>
+<rectangle x1="50.46925" y1="70.19925" x2="51.23125" y2="70.21195" layer="21"/>
+<rectangle x1="51.29475" y1="70.19925" x2="52.05675" y2="70.21195" layer="21"/>
+<rectangle x1="52.62825" y1="70.19925" x2="52.85685" y2="70.21195" layer="21"/>
+<rectangle x1="53.42835" y1="70.19925" x2="54.30465" y2="70.21195" layer="21"/>
+<rectangle x1="54.36815" y1="70.19925" x2="55.11745" y2="70.21195" layer="21"/>
+<rectangle x1="50.48195" y1="70.21195" x2="51.23125" y2="70.22465" layer="21"/>
+<rectangle x1="51.30745" y1="70.21195" x2="52.05675" y2="70.22465" layer="21"/>
+<rectangle x1="52.64095" y1="70.21195" x2="52.86955" y2="70.22465" layer="21"/>
+<rectangle x1="53.42835" y1="70.21195" x2="54.29195" y2="70.22465" layer="21"/>
+<rectangle x1="54.36815" y1="70.21195" x2="55.10475" y2="70.22465" layer="21"/>
+<rectangle x1="50.48195" y1="70.22465" x2="51.23125" y2="70.23735" layer="21"/>
+<rectangle x1="51.32015" y1="70.22465" x2="52.05675" y2="70.23735" layer="21"/>
+<rectangle x1="52.64095" y1="70.22465" x2="52.86955" y2="70.23735" layer="21"/>
+<rectangle x1="53.41565" y1="70.22465" x2="54.27925" y2="70.23735" layer="21"/>
+<rectangle x1="54.36815" y1="70.22465" x2="55.07935" y2="70.23735" layer="21"/>
+<rectangle x1="50.49465" y1="70.23735" x2="51.23125" y2="70.25005" layer="21"/>
+<rectangle x1="51.33285" y1="70.23735" x2="52.06945" y2="70.25005" layer="21"/>
+<rectangle x1="52.65365" y1="70.23735" x2="52.86955" y2="70.25005" layer="21"/>
+<rectangle x1="53.39025" y1="70.23735" x2="54.27925" y2="70.25005" layer="21"/>
+<rectangle x1="54.36815" y1="70.23735" x2="55.05395" y2="70.25005" layer="21"/>
+<rectangle x1="50.52005" y1="70.25005" x2="51.23125" y2="70.26275" layer="21"/>
+<rectangle x1="51.34555" y1="70.25005" x2="52.06945" y2="70.26275" layer="21"/>
+<rectangle x1="52.67905" y1="70.25005" x2="52.86955" y2="70.26275" layer="21"/>
+<rectangle x1="53.37755" y1="70.25005" x2="54.26655" y2="70.26275" layer="21"/>
+<rectangle x1="54.36815" y1="70.25005" x2="54.58405" y2="70.26275" layer="21"/>
+<rectangle x1="54.69835" y1="70.25005" x2="54.93965" y2="70.26275" layer="21"/>
+<rectangle x1="50.55815" y1="70.26275" x2="50.98995" y2="70.27545" layer="21"/>
+<rectangle x1="51.01535" y1="70.26275" x2="51.23125" y2="70.27545" layer="21"/>
+<rectangle x1="51.35825" y1="70.26275" x2="52.06945" y2="70.27545" layer="21"/>
+<rectangle x1="52.69175" y1="70.26275" x2="52.88225" y2="70.27545" layer="21"/>
+<rectangle x1="53.33945" y1="70.26275" x2="54.25385" y2="70.27545" layer="21"/>
+<rectangle x1="54.36815" y1="70.26275" x2="54.59675" y2="70.27545" layer="21"/>
+<rectangle x1="50.71055" y1="70.27545" x2="50.81215" y2="70.28815" layer="21"/>
+<rectangle x1="51.01535" y1="70.27545" x2="51.23125" y2="70.28815" layer="21"/>
+<rectangle x1="51.37095" y1="70.27545" x2="52.06945" y2="70.28815" layer="21"/>
+<rectangle x1="52.70445" y1="70.27545" x2="52.88225" y2="70.28815" layer="21"/>
+<rectangle x1="53.27595" y1="70.27545" x2="54.24115" y2="70.28815" layer="21"/>
+<rectangle x1="54.36815" y1="70.27545" x2="54.59675" y2="70.28815" layer="21"/>
+<rectangle x1="51.01535" y1="70.28815" x2="51.23125" y2="70.30085" layer="21"/>
+<rectangle x1="51.37095" y1="70.28815" x2="51.77735" y2="70.30085" layer="21"/>
+<rectangle x1="51.81545" y1="70.28815" x2="52.08215" y2="70.30085" layer="21"/>
+<rectangle x1="52.71715" y1="70.28815" x2="52.88225" y2="70.30085" layer="21"/>
+<rectangle x1="53.27595" y1="70.28815" x2="54.22845" y2="70.30085" layer="21"/>
+<rectangle x1="54.38085" y1="70.28815" x2="54.59675" y2="70.30085" layer="21"/>
+<rectangle x1="51.01535" y1="70.30085" x2="51.23125" y2="70.31355" layer="21"/>
+<rectangle x1="51.38365" y1="70.30085" x2="51.72655" y2="70.31355" layer="21"/>
+<rectangle x1="51.81545" y1="70.30085" x2="52.08215" y2="70.31355" layer="21"/>
+<rectangle x1="52.74255" y1="70.30085" x2="52.88225" y2="70.31355" layer="21"/>
+<rectangle x1="53.27595" y1="70.30085" x2="54.20305" y2="70.31355" layer="21"/>
+<rectangle x1="54.38085" y1="70.30085" x2="54.59675" y2="70.31355" layer="21"/>
+<rectangle x1="51.01535" y1="70.31355" x2="51.23125" y2="70.32625" layer="21"/>
+<rectangle x1="51.40905" y1="70.31355" x2="51.67575" y2="70.32625" layer="21"/>
+<rectangle x1="51.81545" y1="70.31355" x2="52.08215" y2="70.32625" layer="21"/>
+<rectangle x1="52.74255" y1="70.31355" x2="52.89495" y2="70.32625" layer="21"/>
+<rectangle x1="53.27595" y1="70.31355" x2="54.17765" y2="70.32625" layer="21"/>
+<rectangle x1="54.38085" y1="70.31355" x2="54.59675" y2="70.32625" layer="21"/>
+<rectangle x1="51.01535" y1="70.32625" x2="51.23125" y2="70.33895" layer="21"/>
+<rectangle x1="51.43445" y1="70.32625" x2="51.61225" y2="70.33895" layer="21"/>
+<rectangle x1="51.82815" y1="70.32625" x2="52.09485" y2="70.33895" layer="21"/>
+<rectangle x1="52.75525" y1="70.32625" x2="52.89495" y2="70.33895" layer="21"/>
+<rectangle x1="53.28865" y1="70.32625" x2="54.12685" y2="70.33895" layer="21"/>
+<rectangle x1="54.38085" y1="70.32625" x2="54.59675" y2="70.33895" layer="21"/>
+<rectangle x1="51.01535" y1="70.33895" x2="51.23125" y2="70.35165" layer="21"/>
+<rectangle x1="51.45985" y1="70.33895" x2="51.57415" y2="70.35165" layer="21"/>
+<rectangle x1="51.82815" y1="70.33895" x2="52.09485" y2="70.35165" layer="21"/>
+<rectangle x1="52.75525" y1="70.33895" x2="52.90765" y2="70.35165" layer="21"/>
+<rectangle x1="53.28865" y1="70.33895" x2="53.49185" y2="70.35165" layer="21"/>
+<rectangle x1="53.50455" y1="70.33895" x2="54.10145" y2="70.35165" layer="21"/>
+<rectangle x1="54.38085" y1="70.33895" x2="54.59675" y2="70.35165" layer="21"/>
+<rectangle x1="51.01535" y1="70.35165" x2="51.23125" y2="70.36435" layer="21"/>
+<rectangle x1="51.82815" y1="70.35165" x2="52.09485" y2="70.36435" layer="21"/>
+<rectangle x1="52.75525" y1="70.35165" x2="52.90765" y2="70.36435" layer="21"/>
+<rectangle x1="53.28865" y1="70.35165" x2="53.47915" y2="70.36435" layer="21"/>
+<rectangle x1="53.50455" y1="70.35165" x2="54.12685" y2="70.36435" layer="21"/>
+<rectangle x1="54.38085" y1="70.35165" x2="54.59675" y2="70.36435" layer="21"/>
+<rectangle x1="51.00265" y1="70.36435" x2="51.23125" y2="70.37705" layer="21"/>
+<rectangle x1="51.82815" y1="70.36435" x2="52.10755" y2="70.37705" layer="21"/>
+<rectangle x1="52.75525" y1="70.36435" x2="52.90765" y2="70.37705" layer="21"/>
+<rectangle x1="53.30135" y1="70.36435" x2="53.46645" y2="70.37705" layer="21"/>
+<rectangle x1="53.49185" y1="70.36435" x2="54.15225" y2="70.37705" layer="21"/>
+<rectangle x1="54.38085" y1="70.36435" x2="54.59675" y2="70.37705" layer="21"/>
+<rectangle x1="51.00265" y1="70.37705" x2="51.23125" y2="70.38975" layer="21"/>
+<rectangle x1="51.84085" y1="70.37705" x2="52.10755" y2="70.38975" layer="21"/>
+<rectangle x1="52.76795" y1="70.37705" x2="52.90765" y2="70.38975" layer="21"/>
+<rectangle x1="53.30135" y1="70.37705" x2="53.44105" y2="70.38975" layer="21"/>
+<rectangle x1="53.49185" y1="70.37705" x2="54.16495" y2="70.38975" layer="21"/>
+<rectangle x1="54.38085" y1="70.37705" x2="54.59675" y2="70.38975" layer="21"/>
+<rectangle x1="51.00265" y1="70.38975" x2="51.23125" y2="70.40245" layer="21"/>
+<rectangle x1="51.84085" y1="70.38975" x2="52.12025" y2="70.40245" layer="21"/>
+<rectangle x1="52.76795" y1="70.38975" x2="52.92035" y2="70.40245" layer="21"/>
+<rectangle x1="53.30135" y1="70.38975" x2="53.45375" y2="70.40245" layer="21"/>
+<rectangle x1="53.49185" y1="70.38975" x2="54.19035" y2="70.40245" layer="21"/>
+<rectangle x1="54.38085" y1="70.38975" x2="54.60945" y2="70.40245" layer="21"/>
+<rectangle x1="51.00265" y1="70.40245" x2="51.23125" y2="70.41515" layer="21"/>
+<rectangle x1="51.84085" y1="70.40245" x2="52.12025" y2="70.41515" layer="21"/>
+<rectangle x1="52.76795" y1="70.40245" x2="52.92035" y2="70.41515" layer="21"/>
+<rectangle x1="53.30135" y1="70.40245" x2="53.45375" y2="70.41515" layer="21"/>
+<rectangle x1="53.47915" y1="70.40245" x2="54.21575" y2="70.41515" layer="21"/>
+<rectangle x1="54.38085" y1="70.40245" x2="54.60945" y2="70.41515" layer="21"/>
+<rectangle x1="51.00265" y1="70.41515" x2="51.23125" y2="70.42785" layer="21"/>
+<rectangle x1="51.84085" y1="70.41515" x2="52.12025" y2="70.42785" layer="21"/>
+<rectangle x1="52.76795" y1="70.41515" x2="52.92035" y2="70.42785" layer="21"/>
+<rectangle x1="53.31405" y1="70.41515" x2="53.45375" y2="70.42785" layer="21"/>
+<rectangle x1="53.47915" y1="70.41515" x2="54.22845" y2="70.42785" layer="21"/>
+<rectangle x1="54.38085" y1="70.41515" x2="54.60945" y2="70.42785" layer="21"/>
+<rectangle x1="51.00265" y1="70.42785" x2="51.23125" y2="70.44055" layer="21"/>
+<rectangle x1="51.85355" y1="70.42785" x2="52.13295" y2="70.44055" layer="21"/>
+<rectangle x1="52.78065" y1="70.42785" x2="52.92035" y2="70.44055" layer="21"/>
+<rectangle x1="53.31405" y1="70.42785" x2="53.45375" y2="70.44055" layer="21"/>
+<rectangle x1="53.47915" y1="70.42785" x2="53.87285" y2="70.44055" layer="21"/>
+<rectangle x1="53.92365" y1="70.42785" x2="54.24115" y2="70.44055" layer="21"/>
+<rectangle x1="54.38085" y1="70.42785" x2="54.60945" y2="70.44055" layer="21"/>
+<rectangle x1="51.00265" y1="70.44055" x2="51.23125" y2="70.45325" layer="21"/>
+<rectangle x1="51.85355" y1="70.44055" x2="52.13295" y2="70.45325" layer="21"/>
+<rectangle x1="52.78065" y1="70.44055" x2="52.93305" y2="70.45325" layer="21"/>
+<rectangle x1="53.31405" y1="70.44055" x2="53.87285" y2="70.45325" layer="21"/>
+<rectangle x1="53.97445" y1="70.44055" x2="54.25385" y2="70.45325" layer="21"/>
+<rectangle x1="54.38085" y1="70.44055" x2="54.60945" y2="70.45325" layer="21"/>
+<rectangle x1="51.00265" y1="70.45325" x2="51.23125" y2="70.46595" layer="21"/>
+<rectangle x1="51.86625" y1="70.45325" x2="52.13295" y2="70.46595" layer="21"/>
+<rectangle x1="52.78065" y1="70.45325" x2="52.93305" y2="70.46595" layer="21"/>
+<rectangle x1="53.31405" y1="70.45325" x2="53.78395" y2="70.46595" layer="21"/>
+<rectangle x1="53.82205" y1="70.45325" x2="53.87285" y2="70.46595" layer="21"/>
+<rectangle x1="54.01255" y1="70.45325" x2="54.26655" y2="70.46595" layer="21"/>
+<rectangle x1="54.38085" y1="70.45325" x2="54.60945" y2="70.46595" layer="21"/>
+<rectangle x1="51.00265" y1="70.46595" x2="51.23125" y2="70.47865" layer="21"/>
+<rectangle x1="51.86625" y1="70.46595" x2="52.14565" y2="70.47865" layer="21"/>
+<rectangle x1="52.78065" y1="70.46595" x2="52.93305" y2="70.47865" layer="21"/>
+<rectangle x1="53.32675" y1="70.46595" x2="53.75855" y2="70.47865" layer="21"/>
+<rectangle x1="53.83475" y1="70.46595" x2="53.87285" y2="70.47865" layer="21"/>
+<rectangle x1="54.05065" y1="70.46595" x2="54.27925" y2="70.47865" layer="21"/>
+<rectangle x1="54.38085" y1="70.46595" x2="54.60945" y2="70.47865" layer="21"/>
+<rectangle x1="51.00265" y1="70.47865" x2="51.23125" y2="70.49135" layer="21"/>
+<rectangle x1="51.86625" y1="70.47865" x2="52.14565" y2="70.49135" layer="21"/>
+<rectangle x1="52.79335" y1="70.47865" x2="52.93305" y2="70.49135" layer="21"/>
+<rectangle x1="53.32675" y1="70.47865" x2="53.74585" y2="70.49135" layer="21"/>
+<rectangle x1="53.84745" y1="70.47865" x2="53.87285" y2="70.49135" layer="21"/>
+<rectangle x1="54.07605" y1="70.47865" x2="54.29195" y2="70.49135" layer="21"/>
+<rectangle x1="54.38085" y1="70.47865" x2="54.60945" y2="70.49135" layer="21"/>
+<rectangle x1="51.00265" y1="70.49135" x2="51.23125" y2="70.50405" layer="21"/>
+<rectangle x1="51.87895" y1="70.49135" x2="52.15835" y2="70.50405" layer="21"/>
+<rectangle x1="52.79335" y1="70.49135" x2="52.94575" y2="70.50405" layer="21"/>
+<rectangle x1="53.32675" y1="70.49135" x2="53.74585" y2="70.50405" layer="21"/>
+<rectangle x1="53.86015" y1="70.49135" x2="53.87285" y2="70.50405" layer="21"/>
+<rectangle x1="54.08875" y1="70.49135" x2="54.30465" y2="70.50405" layer="21"/>
+<rectangle x1="54.38085" y1="70.49135" x2="54.60945" y2="70.50405" layer="21"/>
+<rectangle x1="51.00265" y1="70.50405" x2="51.23125" y2="70.51675" layer="21"/>
+<rectangle x1="51.87895" y1="70.50405" x2="52.15835" y2="70.51675" layer="21"/>
+<rectangle x1="52.79335" y1="70.50405" x2="52.94575" y2="70.51675" layer="21"/>
+<rectangle x1="53.33945" y1="70.50405" x2="53.73315" y2="70.51675" layer="21"/>
+<rectangle x1="54.11415" y1="70.50405" x2="54.31735" y2="70.51675" layer="21"/>
+<rectangle x1="54.36815" y1="70.50405" x2="54.60945" y2="70.51675" layer="21"/>
+<rectangle x1="51.00265" y1="70.51675" x2="51.23125" y2="70.52945" layer="21"/>
+<rectangle x1="51.87895" y1="70.51675" x2="52.17105" y2="70.52945" layer="21"/>
+<rectangle x1="52.79335" y1="70.51675" x2="52.94575" y2="70.52945" layer="21"/>
+<rectangle x1="53.33945" y1="70.51675" x2="53.72045" y2="70.52945" layer="21"/>
+<rectangle x1="54.12685" y1="70.51675" x2="54.31735" y2="70.52945" layer="21"/>
+<rectangle x1="54.36815" y1="70.51675" x2="54.60945" y2="70.52945" layer="21"/>
+<rectangle x1="51.00265" y1="70.52945" x2="51.23125" y2="70.54215" layer="21"/>
+<rectangle x1="51.89165" y1="70.52945" x2="52.17105" y2="70.54215" layer="21"/>
+<rectangle x1="52.80605" y1="70.52945" x2="52.95845" y2="70.54215" layer="21"/>
+<rectangle x1="53.33945" y1="70.52945" x2="53.72045" y2="70.54215" layer="21"/>
+<rectangle x1="54.13955" y1="70.52945" x2="54.33005" y2="70.54215" layer="21"/>
+<rectangle x1="54.36815" y1="70.52945" x2="54.60945" y2="70.54215" layer="21"/>
+<rectangle x1="51.00265" y1="70.54215" x2="51.23125" y2="70.55485" layer="21"/>
+<rectangle x1="51.89165" y1="70.54215" x2="52.18375" y2="70.55485" layer="21"/>
+<rectangle x1="52.80605" y1="70.54215" x2="52.95845" y2="70.55485" layer="21"/>
+<rectangle x1="53.35215" y1="70.54215" x2="53.70775" y2="70.55485" layer="21"/>
+<rectangle x1="54.15225" y1="70.54215" x2="54.33005" y2="70.55485" layer="21"/>
+<rectangle x1="54.36815" y1="70.54215" x2="54.60945" y2="70.55485" layer="21"/>
+<rectangle x1="51.00265" y1="70.55485" x2="51.23125" y2="70.56755" layer="21"/>
+<rectangle x1="51.89165" y1="70.55485" x2="52.18375" y2="70.56755" layer="21"/>
+<rectangle x1="52.81875" y1="70.55485" x2="52.95845" y2="70.56755" layer="21"/>
+<rectangle x1="53.35215" y1="70.55485" x2="53.70775" y2="70.56755" layer="21"/>
+<rectangle x1="54.16495" y1="70.55485" x2="54.34275" y2="70.56755" layer="21"/>
+<rectangle x1="54.36815" y1="70.55485" x2="54.60945" y2="70.56755" layer="21"/>
+<rectangle x1="51.00265" y1="70.56755" x2="51.23125" y2="70.58025" layer="21"/>
+<rectangle x1="51.90435" y1="70.56755" x2="52.19645" y2="70.58025" layer="21"/>
+<rectangle x1="52.81875" y1="70.56755" x2="52.97115" y2="70.58025" layer="21"/>
+<rectangle x1="53.36485" y1="70.56755" x2="53.70775" y2="70.58025" layer="21"/>
+<rectangle x1="54.17765" y1="70.56755" x2="54.35545" y2="70.58025" layer="21"/>
+<rectangle x1="54.36815" y1="70.56755" x2="54.60945" y2="70.58025" layer="21"/>
+<rectangle x1="51.00265" y1="70.58025" x2="51.23125" y2="70.59295" layer="21"/>
+<rectangle x1="51.91705" y1="70.58025" x2="52.20915" y2="70.59295" layer="21"/>
+<rectangle x1="52.81875" y1="70.58025" x2="52.97115" y2="70.59295" layer="21"/>
+<rectangle x1="53.36485" y1="70.58025" x2="53.69505" y2="70.59295" layer="21"/>
+<rectangle x1="54.19035" y1="70.58025" x2="54.35545" y2="70.59295" layer="21"/>
+<rectangle x1="54.36815" y1="70.58025" x2="54.60945" y2="70.59295" layer="21"/>
+<rectangle x1="51.00265" y1="70.59295" x2="51.23125" y2="70.60565" layer="21"/>
+<rectangle x1="51.91705" y1="70.59295" x2="52.20915" y2="70.60565" layer="21"/>
+<rectangle x1="52.81875" y1="70.59295" x2="52.97115" y2="70.60565" layer="21"/>
+<rectangle x1="53.36485" y1="70.59295" x2="53.69505" y2="70.60565" layer="21"/>
+<rectangle x1="54.20305" y1="70.59295" x2="54.60945" y2="70.60565" layer="21"/>
+<rectangle x1="51.00265" y1="70.60565" x2="51.24395" y2="70.61835" layer="21"/>
+<rectangle x1="51.92975" y1="70.60565" x2="52.22185" y2="70.61835" layer="21"/>
+<rectangle x1="52.83145" y1="70.60565" x2="52.98385" y2="70.61835" layer="21"/>
+<rectangle x1="53.37755" y1="70.60565" x2="53.69505" y2="70.61835" layer="21"/>
+<rectangle x1="54.21575" y1="70.60565" x2="54.59675" y2="70.61835" layer="21"/>
+<rectangle x1="51.00265" y1="70.61835" x2="51.24395" y2="70.63105" layer="21"/>
+<rectangle x1="51.92975" y1="70.61835" x2="52.22185" y2="70.63105" layer="21"/>
+<rectangle x1="52.83145" y1="70.61835" x2="52.98385" y2="70.63105" layer="21"/>
+<rectangle x1="53.37755" y1="70.61835" x2="53.69505" y2="70.63105" layer="21"/>
+<rectangle x1="54.21575" y1="70.61835" x2="54.59675" y2="70.63105" layer="21"/>
+<rectangle x1="51.00265" y1="70.63105" x2="51.24395" y2="70.64375" layer="21"/>
+<rectangle x1="51.92975" y1="70.63105" x2="52.23455" y2="70.64375" layer="21"/>
+<rectangle x1="52.83145" y1="70.63105" x2="52.98385" y2="70.64375" layer="21"/>
+<rectangle x1="53.39025" y1="70.63105" x2="53.69505" y2="70.64375" layer="21"/>
+<rectangle x1="54.22845" y1="70.63105" x2="54.59675" y2="70.64375" layer="21"/>
+<rectangle x1="51.00265" y1="70.64375" x2="51.24395" y2="70.65645" layer="21"/>
+<rectangle x1="51.94245" y1="70.64375" x2="52.23455" y2="70.65645" layer="21"/>
+<rectangle x1="52.84415" y1="70.64375" x2="52.99655" y2="70.65645" layer="21"/>
+<rectangle x1="53.39025" y1="70.64375" x2="53.70775" y2="70.65645" layer="21"/>
+<rectangle x1="54.22845" y1="70.64375" x2="54.59675" y2="70.65645" layer="21"/>
+<rectangle x1="51.00265" y1="70.65645" x2="51.24395" y2="70.66915" layer="21"/>
+<rectangle x1="51.95515" y1="70.65645" x2="52.24725" y2="70.66915" layer="21"/>
+<rectangle x1="52.84415" y1="70.65645" x2="52.99655" y2="70.66915" layer="21"/>
+<rectangle x1="53.40295" y1="70.65645" x2="53.70775" y2="70.66915" layer="21"/>
+<rectangle x1="54.24115" y1="70.65645" x2="54.59675" y2="70.66915" layer="21"/>
+<rectangle x1="51.00265" y1="70.66915" x2="51.24395" y2="70.68185" layer="21"/>
+<rectangle x1="51.95515" y1="70.66915" x2="52.25995" y2="70.68185" layer="21"/>
+<rectangle x1="52.84415" y1="70.66915" x2="52.99655" y2="70.68185" layer="21"/>
+<rectangle x1="53.41565" y1="70.66915" x2="53.70775" y2="70.68185" layer="21"/>
+<rectangle x1="54.24115" y1="70.66915" x2="54.59675" y2="70.68185" layer="21"/>
+<rectangle x1="51.00265" y1="70.68185" x2="51.24395" y2="70.69455" layer="21"/>
+<rectangle x1="51.96785" y1="70.68185" x2="52.25995" y2="70.69455" layer="21"/>
+<rectangle x1="52.85685" y1="70.68185" x2="53.00925" y2="70.69455" layer="21"/>
+<rectangle x1="53.41565" y1="70.68185" x2="53.72045" y2="70.69455" layer="21"/>
+<rectangle x1="54.25385" y1="70.68185" x2="54.59675" y2="70.69455" layer="21"/>
+<rectangle x1="51.00265" y1="70.69455" x2="51.24395" y2="70.70725" layer="21"/>
+<rectangle x1="51.98055" y1="70.69455" x2="52.27265" y2="70.70725" layer="21"/>
+<rectangle x1="52.85685" y1="70.69455" x2="53.00925" y2="70.70725" layer="21"/>
+<rectangle x1="53.41565" y1="70.69455" x2="53.72045" y2="70.70725" layer="21"/>
+<rectangle x1="54.25385" y1="70.69455" x2="54.59675" y2="70.70725" layer="21"/>
+<rectangle x1="51.01535" y1="70.70725" x2="51.24395" y2="70.71995" layer="21"/>
+<rectangle x1="51.98055" y1="70.70725" x2="52.28535" y2="70.71995" layer="21"/>
+<rectangle x1="52.86955" y1="70.70725" x2="53.02195" y2="70.71995" layer="21"/>
+<rectangle x1="53.42835" y1="70.70725" x2="53.73315" y2="70.71995" layer="21"/>
+<rectangle x1="54.26655" y1="70.70725" x2="54.59675" y2="70.71995" layer="21"/>
+<rectangle x1="51.01535" y1="70.71995" x2="51.25665" y2="70.73265" layer="21"/>
+<rectangle x1="51.99325" y1="70.71995" x2="52.28535" y2="70.73265" layer="21"/>
+<rectangle x1="52.86955" y1="70.71995" x2="53.02195" y2="70.73265" layer="21"/>
+<rectangle x1="53.42835" y1="70.71995" x2="53.73315" y2="70.73265" layer="21"/>
+<rectangle x1="54.26655" y1="70.71995" x2="54.59675" y2="70.73265" layer="21"/>
+<rectangle x1="51.01535" y1="70.73265" x2="51.25665" y2="70.74535" layer="21"/>
+<rectangle x1="51.99325" y1="70.73265" x2="52.29805" y2="70.74535" layer="21"/>
+<rectangle x1="52.86955" y1="70.73265" x2="53.02195" y2="70.74535" layer="21"/>
+<rectangle x1="53.44105" y1="70.73265" x2="53.75855" y2="70.74535" layer="21"/>
+<rectangle x1="54.27925" y1="70.73265" x2="54.59675" y2="70.74535" layer="21"/>
+<rectangle x1="51.01535" y1="70.74535" x2="51.25665" y2="70.75805" layer="21"/>
+<rectangle x1="52.00595" y1="70.74535" x2="52.31075" y2="70.75805" layer="21"/>
+<rectangle x1="52.88225" y1="70.74535" x2="53.03465" y2="70.75805" layer="21"/>
+<rectangle x1="53.45375" y1="70.74535" x2="53.77125" y2="70.75805" layer="21"/>
+<rectangle x1="54.27925" y1="70.74535" x2="54.59675" y2="70.75805" layer="21"/>
+<rectangle x1="51.01535" y1="70.75805" x2="51.25665" y2="70.77075" layer="21"/>
+<rectangle x1="52.00595" y1="70.75805" x2="52.32345" y2="70.77075" layer="21"/>
+<rectangle x1="52.88225" y1="70.75805" x2="53.03465" y2="70.77075" layer="21"/>
+<rectangle x1="53.46645" y1="70.75805" x2="53.78395" y2="70.77075" layer="21"/>
+<rectangle x1="54.27925" y1="70.75805" x2="54.58405" y2="70.77075" layer="21"/>
+<rectangle x1="51.01535" y1="70.77075" x2="51.25665" y2="70.78345" layer="21"/>
+<rectangle x1="52.00595" y1="70.77075" x2="52.32345" y2="70.78345" layer="21"/>
+<rectangle x1="52.89495" y1="70.77075" x2="53.04735" y2="70.78345" layer="21"/>
+<rectangle x1="53.46645" y1="70.77075" x2="53.80935" y2="70.78345" layer="21"/>
+<rectangle x1="54.29195" y1="70.77075" x2="54.58405" y2="70.78345" layer="21"/>
+<rectangle x1="51.01535" y1="70.78345" x2="51.25665" y2="70.79615" layer="21"/>
+<rectangle x1="52.01865" y1="70.78345" x2="52.33615" y2="70.79615" layer="21"/>
+<rectangle x1="52.89495" y1="70.78345" x2="53.04735" y2="70.79615" layer="21"/>
+<rectangle x1="53.47915" y1="70.78345" x2="53.83475" y2="70.79615" layer="21"/>
+<rectangle x1="54.29195" y1="70.78345" x2="54.58405" y2="70.79615" layer="21"/>
+<rectangle x1="51.01535" y1="70.79615" x2="51.26935" y2="70.80885" layer="21"/>
+<rectangle x1="52.01865" y1="70.79615" x2="52.34885" y2="70.80885" layer="21"/>
+<rectangle x1="52.90765" y1="70.79615" x2="53.06005" y2="70.80885" layer="21"/>
+<rectangle x1="53.49185" y1="70.79615" x2="53.87285" y2="70.80885" layer="21"/>
+<rectangle x1="54.29195" y1="70.79615" x2="54.58405" y2="70.80885" layer="21"/>
+<rectangle x1="51.02805" y1="70.80885" x2="51.26935" y2="70.82155" layer="21"/>
+<rectangle x1="52.01865" y1="70.80885" x2="52.36155" y2="70.82155" layer="21"/>
+<rectangle x1="52.90765" y1="70.80885" x2="53.06005" y2="70.82155" layer="21"/>
+<rectangle x1="53.50455" y1="70.80885" x2="53.88555" y2="70.82155" layer="21"/>
+<rectangle x1="54.29195" y1="70.80885" x2="54.58405" y2="70.82155" layer="21"/>
+<rectangle x1="51.02805" y1="70.82155" x2="51.26935" y2="70.83425" layer="21"/>
+<rectangle x1="52.01865" y1="70.82155" x2="52.36155" y2="70.83425" layer="21"/>
+<rectangle x1="52.90765" y1="70.82155" x2="53.07275" y2="70.83425" layer="21"/>
+<rectangle x1="53.50455" y1="70.82155" x2="53.89825" y2="70.83425" layer="21"/>
+<rectangle x1="54.30465" y1="70.82155" x2="54.58405" y2="70.83425" layer="21"/>
+<rectangle x1="51.02805" y1="70.83425" x2="51.28205" y2="70.84695" layer="21"/>
+<rectangle x1="52.00595" y1="70.83425" x2="52.37425" y2="70.84695" layer="21"/>
+<rectangle x1="52.92035" y1="70.83425" x2="53.07275" y2="70.84695" layer="21"/>
+<rectangle x1="53.51725" y1="70.83425" x2="53.91095" y2="70.84695" layer="21"/>
+<rectangle x1="54.30465" y1="70.83425" x2="54.58405" y2="70.84695" layer="21"/>
+<rectangle x1="51.02805" y1="70.84695" x2="51.28205" y2="70.85965" layer="21"/>
+<rectangle x1="52.00595" y1="70.84695" x2="52.39965" y2="70.85965" layer="21"/>
+<rectangle x1="52.92035" y1="70.84695" x2="53.08545" y2="70.85965" layer="21"/>
+<rectangle x1="53.52995" y1="70.84695" x2="53.92365" y2="70.85965" layer="21"/>
+<rectangle x1="54.30465" y1="70.84695" x2="54.57135" y2="70.85965" layer="21"/>
+<rectangle x1="51.02805" y1="70.85965" x2="51.28205" y2="70.87235" layer="21"/>
+<rectangle x1="52.00595" y1="70.85965" x2="52.39965" y2="70.87235" layer="21"/>
+<rectangle x1="52.93305" y1="70.85965" x2="53.08545" y2="70.87235" layer="21"/>
+<rectangle x1="53.54265" y1="70.85965" x2="53.92365" y2="70.87235" layer="21"/>
+<rectangle x1="54.30465" y1="70.85965" x2="54.57135" y2="70.87235" layer="21"/>
+<rectangle x1="51.02805" y1="70.87235" x2="51.28205" y2="70.88505" layer="21"/>
+<rectangle x1="51.99325" y1="70.87235" x2="52.41235" y2="70.88505" layer="21"/>
+<rectangle x1="52.93305" y1="70.87235" x2="53.09815" y2="70.88505" layer="21"/>
+<rectangle x1="53.55535" y1="70.87235" x2="53.92365" y2="70.88505" layer="21"/>
+<rectangle x1="54.30465" y1="70.87235" x2="54.57135" y2="70.88505" layer="21"/>
+<rectangle x1="51.04075" y1="70.88505" x2="51.29475" y2="70.89775" layer="21"/>
+<rectangle x1="51.99325" y1="70.88505" x2="52.42505" y2="70.89775" layer="21"/>
+<rectangle x1="52.94575" y1="70.88505" x2="53.11085" y2="70.89775" layer="21"/>
+<rectangle x1="53.56805" y1="70.88505" x2="53.92365" y2="70.89775" layer="21"/>
+<rectangle x1="54.30465" y1="70.88505" x2="54.57135" y2="70.89775" layer="21"/>
+<rectangle x1="51.04075" y1="70.89775" x2="51.29475" y2="70.91045" layer="21"/>
+<rectangle x1="51.99325" y1="70.89775" x2="52.43775" y2="70.91045" layer="21"/>
+<rectangle x1="52.94575" y1="70.89775" x2="53.11085" y2="70.91045" layer="21"/>
+<rectangle x1="53.59345" y1="70.89775" x2="53.92365" y2="70.91045" layer="21"/>
+<rectangle x1="54.30465" y1="70.89775" x2="54.57135" y2="70.91045" layer="21"/>
+<rectangle x1="51.04075" y1="70.91045" x2="51.29475" y2="70.92315" layer="21"/>
+<rectangle x1="51.98055" y1="70.91045" x2="52.45045" y2="70.92315" layer="21"/>
+<rectangle x1="52.95845" y1="70.91045" x2="53.12355" y2="70.92315" layer="21"/>
+<rectangle x1="53.60615" y1="70.91045" x2="53.92365" y2="70.92315" layer="21"/>
+<rectangle x1="54.30465" y1="70.91045" x2="54.57135" y2="70.92315" layer="21"/>
+<rectangle x1="51.04075" y1="70.92315" x2="51.29475" y2="70.93585" layer="21"/>
+<rectangle x1="51.98055" y1="70.92315" x2="52.46315" y2="70.93585" layer="21"/>
+<rectangle x1="52.95845" y1="70.92315" x2="53.12355" y2="70.93585" layer="21"/>
+<rectangle x1="53.61885" y1="70.92315" x2="53.92365" y2="70.93585" layer="21"/>
+<rectangle x1="54.30465" y1="70.92315" x2="54.55865" y2="70.93585" layer="21"/>
+<rectangle x1="51.04075" y1="70.93585" x2="51.30745" y2="70.94855" layer="21"/>
+<rectangle x1="51.96785" y1="70.93585" x2="52.47585" y2="70.94855" layer="21"/>
+<rectangle x1="52.97115" y1="70.93585" x2="53.13625" y2="70.94855" layer="21"/>
+<rectangle x1="53.64425" y1="70.93585" x2="53.91095" y2="70.94855" layer="21"/>
+<rectangle x1="54.30465" y1="70.93585" x2="54.55865" y2="70.94855" layer="21"/>
+<rectangle x1="51.05345" y1="70.94855" x2="51.30745" y2="70.96125" layer="21"/>
+<rectangle x1="51.96785" y1="70.94855" x2="52.48855" y2="70.96125" layer="21"/>
+<rectangle x1="52.97115" y1="70.94855" x2="53.13625" y2="70.96125" layer="21"/>
+<rectangle x1="53.66965" y1="70.94855" x2="53.89825" y2="70.96125" layer="21"/>
+<rectangle x1="54.30465" y1="70.94855" x2="54.55865" y2="70.96125" layer="21"/>
+<rectangle x1="51.05345" y1="70.96125" x2="51.32015" y2="70.97395" layer="21"/>
+<rectangle x1="51.95515" y1="70.96125" x2="52.50125" y2="70.97395" layer="21"/>
+<rectangle x1="52.98385" y1="70.96125" x2="53.14895" y2="70.97395" layer="21"/>
+<rectangle x1="53.70775" y1="70.96125" x2="53.88555" y2="70.97395" layer="21"/>
+<rectangle x1="54.30465" y1="70.96125" x2="54.55865" y2="70.97395" layer="21"/>
+<rectangle x1="51.06615" y1="70.97395" x2="51.32015" y2="70.98665" layer="21"/>
+<rectangle x1="51.95515" y1="70.97395" x2="52.51395" y2="70.98665" layer="21"/>
+<rectangle x1="52.98385" y1="70.97395" x2="53.16165" y2="70.98665" layer="21"/>
+<rectangle x1="53.75855" y1="70.97395" x2="53.86015" y2="70.98665" layer="21"/>
+<rectangle x1="54.30465" y1="70.97395" x2="54.54595" y2="70.98665" layer="21"/>
+<rectangle x1="51.06615" y1="70.98665" x2="51.32015" y2="70.99935" layer="21"/>
+<rectangle x1="51.94245" y1="70.98665" x2="52.52665" y2="70.99935" layer="21"/>
+<rectangle x1="52.99655" y1="70.98665" x2="53.17435" y2="70.99935" layer="21"/>
+<rectangle x1="54.29195" y1="70.98665" x2="54.54595" y2="70.99935" layer="21"/>
+<rectangle x1="51.06615" y1="70.99935" x2="51.33285" y2="71.01205" layer="21"/>
+<rectangle x1="51.94245" y1="70.99935" x2="52.53935" y2="71.01205" layer="21"/>
+<rectangle x1="53.00925" y1="70.99935" x2="53.17435" y2="71.01205" layer="21"/>
+<rectangle x1="54.29195" y1="70.99935" x2="54.53325" y2="71.01205" layer="21"/>
+<rectangle x1="51.06615" y1="71.01205" x2="51.33285" y2="71.02475" layer="21"/>
+<rectangle x1="51.92975" y1="71.01205" x2="52.18375" y2="71.02475" layer="21"/>
+<rectangle x1="52.20915" y1="71.01205" x2="52.56475" y2="71.02475" layer="21"/>
+<rectangle x1="53.00925" y1="71.01205" x2="53.18705" y2="71.02475" layer="21"/>
+<rectangle x1="54.29195" y1="71.01205" x2="54.53325" y2="71.02475" layer="21"/>
+<rectangle x1="51.07885" y1="71.02475" x2="51.33285" y2="71.03745" layer="21"/>
+<rectangle x1="51.92975" y1="71.02475" x2="52.18375" y2="71.03745" layer="21"/>
+<rectangle x1="52.22185" y1="71.02475" x2="52.57745" y2="71.03745" layer="21"/>
+<rectangle x1="53.02195" y1="71.02475" x2="53.18705" y2="71.03745" layer="21"/>
+<rectangle x1="54.27925" y1="71.02475" x2="54.53325" y2="71.03745" layer="21"/>
+<rectangle x1="51.07885" y1="71.03745" x2="51.34555" y2="71.05015" layer="21"/>
+<rectangle x1="51.91705" y1="71.03745" x2="52.17105" y2="71.05015" layer="21"/>
+<rectangle x1="52.23455" y1="71.03745" x2="52.59015" y2="71.05015" layer="21"/>
+<rectangle x1="53.02195" y1="71.03745" x2="53.19975" y2="71.05015" layer="21"/>
+<rectangle x1="54.27925" y1="71.03745" x2="54.53325" y2="71.05015" layer="21"/>
+<rectangle x1="51.07885" y1="71.05015" x2="51.35825" y2="71.06285" layer="21"/>
+<rectangle x1="51.90435" y1="71.05015" x2="52.17105" y2="71.06285" layer="21"/>
+<rectangle x1="52.25995" y1="71.05015" x2="52.61555" y2="71.06285" layer="21"/>
+<rectangle x1="52.99655" y1="71.05015" x2="53.21245" y2="71.06285" layer="21"/>
+<rectangle x1="54.27925" y1="71.05015" x2="54.52055" y2="71.06285" layer="21"/>
+<rectangle x1="51.09155" y1="71.06285" x2="51.35825" y2="71.07555" layer="21"/>
+<rectangle x1="51.89165" y1="71.06285" x2="52.17105" y2="71.07555" layer="21"/>
+<rectangle x1="52.25995" y1="71.06285" x2="52.61555" y2="71.07555" layer="21"/>
+<rectangle x1="52.98385" y1="71.06285" x2="53.22515" y2="71.07555" layer="21"/>
+<rectangle x1="54.26655" y1="71.06285" x2="54.52055" y2="71.07555" layer="21"/>
+<rectangle x1="51.09155" y1="71.07555" x2="51.35825" y2="71.08825" layer="21"/>
+<rectangle x1="51.89165" y1="71.07555" x2="52.15835" y2="71.08825" layer="21"/>
+<rectangle x1="52.27265" y1="71.07555" x2="52.64095" y2="71.08825" layer="21"/>
+<rectangle x1="52.97115" y1="71.07555" x2="53.23785" y2="71.08825" layer="21"/>
+<rectangle x1="54.26655" y1="71.07555" x2="54.52055" y2="71.08825" layer="21"/>
+<rectangle x1="51.09155" y1="71.08825" x2="51.37095" y2="71.10095" layer="21"/>
+<rectangle x1="51.87895" y1="71.08825" x2="52.14565" y2="71.10095" layer="21"/>
+<rectangle x1="52.28535" y1="71.08825" x2="52.65365" y2="71.10095" layer="21"/>
+<rectangle x1="52.95845" y1="71.08825" x2="53.25055" y2="71.10095" layer="21"/>
+<rectangle x1="54.26655" y1="71.08825" x2="54.50785" y2="71.10095" layer="21"/>
+<rectangle x1="51.10425" y1="71.10095" x2="51.37095" y2="71.11365" layer="21"/>
+<rectangle x1="51.86625" y1="71.10095" x2="52.14565" y2="71.11365" layer="21"/>
+<rectangle x1="52.29805" y1="71.10095" x2="52.67905" y2="71.11365" layer="21"/>
+<rectangle x1="52.93305" y1="71.10095" x2="53.26325" y2="71.11365" layer="21"/>
+<rectangle x1="54.25385" y1="71.10095" x2="54.50785" y2="71.11365" layer="21"/>
+<rectangle x1="51.10425" y1="71.11365" x2="51.38365" y2="71.12635" layer="21"/>
+<rectangle x1="51.85355" y1="71.11365" x2="52.13295" y2="71.12635" layer="21"/>
+<rectangle x1="52.32345" y1="71.11365" x2="52.69175" y2="71.12635" layer="21"/>
+<rectangle x1="52.92035" y1="71.11365" x2="53.27595" y2="71.12635" layer="21"/>
+<rectangle x1="54.24115" y1="71.11365" x2="54.50785" y2="71.12635" layer="21"/>
+<rectangle x1="51.10425" y1="71.12635" x2="51.38365" y2="71.13905" layer="21"/>
+<rectangle x1="51.84085" y1="71.12635" x2="52.13295" y2="71.13905" layer="21"/>
+<rectangle x1="52.32345" y1="71.12635" x2="52.71715" y2="71.13905" layer="21"/>
+<rectangle x1="52.90765" y1="71.12635" x2="53.28865" y2="71.13905" layer="21"/>
+<rectangle x1="54.24115" y1="71.12635" x2="54.49515" y2="71.13905" layer="21"/>
+<rectangle x1="51.11695" y1="71.13905" x2="51.39635" y2="71.15175" layer="21"/>
+<rectangle x1="51.82815" y1="71.13905" x2="52.12025" y2="71.15175" layer="21"/>
+<rectangle x1="52.34885" y1="71.13905" x2="52.72985" y2="71.15175" layer="21"/>
+<rectangle x1="52.88225" y1="71.13905" x2="53.30135" y2="71.15175" layer="21"/>
+<rectangle x1="54.22845" y1="71.13905" x2="54.49515" y2="71.15175" layer="21"/>
+<rectangle x1="51.12965" y1="71.15175" x2="51.39635" y2="71.16445" layer="21"/>
+<rectangle x1="51.81545" y1="71.15175" x2="52.10755" y2="71.16445" layer="21"/>
+<rectangle x1="52.36155" y1="71.15175" x2="52.75525" y2="71.16445" layer="21"/>
+<rectangle x1="52.85685" y1="71.15175" x2="53.31405" y2="71.16445" layer="21"/>
+<rectangle x1="54.22845" y1="71.15175" x2="54.48245" y2="71.16445" layer="21"/>
+<rectangle x1="51.12965" y1="71.16445" x2="51.40905" y2="71.17715" layer="21"/>
+<rectangle x1="51.80275" y1="71.16445" x2="52.10755" y2="71.17715" layer="21"/>
+<rectangle x1="52.37425" y1="71.16445" x2="52.76795" y2="71.17715" layer="21"/>
+<rectangle x1="52.84415" y1="71.16445" x2="53.32675" y2="71.17715" layer="21"/>
+<rectangle x1="54.21575" y1="71.16445" x2="54.48245" y2="71.17715" layer="21"/>
+<rectangle x1="51.12965" y1="71.17715" x2="51.40905" y2="71.18985" layer="21"/>
+<rectangle x1="51.79005" y1="71.17715" x2="52.09485" y2="71.18985" layer="21"/>
+<rectangle x1="52.38695" y1="71.17715" x2="52.79335" y2="71.18985" layer="21"/>
+<rectangle x1="52.81875" y1="71.17715" x2="53.33945" y2="71.18985" layer="21"/>
+<rectangle x1="54.20305" y1="71.17715" x2="54.46975" y2="71.18985" layer="21"/>
+<rectangle x1="51.14235" y1="71.18985" x2="51.42175" y2="71.20255" layer="21"/>
+<rectangle x1="51.77735" y1="71.18985" x2="52.08215" y2="71.20255" layer="21"/>
+<rectangle x1="52.39965" y1="71.18985" x2="53.36485" y2="71.20255" layer="21"/>
+<rectangle x1="54.19035" y1="71.18985" x2="54.46975" y2="71.20255" layer="21"/>
+<rectangle x1="51.14235" y1="71.20255" x2="51.42175" y2="71.21525" layer="21"/>
+<rectangle x1="51.77735" y1="71.20255" x2="52.08215" y2="71.21525" layer="21"/>
+<rectangle x1="52.41235" y1="71.20255" x2="53.36485" y2="71.21525" layer="21"/>
+<rectangle x1="54.19035" y1="71.20255" x2="54.45705" y2="71.21525" layer="21"/>
+<rectangle x1="51.15505" y1="71.21525" x2="51.43445" y2="71.22795" layer="21"/>
+<rectangle x1="51.76465" y1="71.21525" x2="52.06945" y2="71.22795" layer="21"/>
+<rectangle x1="52.43775" y1="71.21525" x2="53.39025" y2="71.22795" layer="21"/>
+<rectangle x1="54.17765" y1="71.21525" x2="54.45705" y2="71.22795" layer="21"/>
+<rectangle x1="51.16775" y1="71.22795" x2="51.44715" y2="71.24065" layer="21"/>
+<rectangle x1="51.73925" y1="71.22795" x2="52.05675" y2="71.24065" layer="21"/>
+<rectangle x1="52.45045" y1="71.22795" x2="53.16165" y2="71.24065" layer="21"/>
+<rectangle x1="53.18705" y1="71.22795" x2="53.41565" y2="71.24065" layer="21"/>
+<rectangle x1="54.16495" y1="71.22795" x2="54.44435" y2="71.24065" layer="21"/>
+<rectangle x1="51.16775" y1="71.24065" x2="51.44715" y2="71.25335" layer="21"/>
+<rectangle x1="51.72655" y1="71.24065" x2="52.04405" y2="71.25335" layer="21"/>
+<rectangle x1="52.47585" y1="71.24065" x2="53.13625" y2="71.25335" layer="21"/>
+<rectangle x1="53.19975" y1="71.24065" x2="53.42835" y2="71.25335" layer="21"/>
+<rectangle x1="54.15225" y1="71.24065" x2="54.44435" y2="71.25335" layer="21"/>
+<rectangle x1="51.18045" y1="71.25335" x2="51.45985" y2="71.26605" layer="21"/>
+<rectangle x1="51.71385" y1="71.25335" x2="52.03135" y2="71.26605" layer="21"/>
+<rectangle x1="52.48855" y1="71.25335" x2="53.12355" y2="71.26605" layer="21"/>
+<rectangle x1="53.21245" y1="71.25335" x2="53.45375" y2="71.26605" layer="21"/>
+<rectangle x1="54.12685" y1="71.25335" x2="54.43165" y2="71.26605" layer="21"/>
+<rectangle x1="51.18045" y1="71.26605" x2="51.47255" y2="71.27875" layer="21"/>
+<rectangle x1="51.70115" y1="71.26605" x2="52.03135" y2="71.27875" layer="21"/>
+<rectangle x1="52.50125" y1="71.26605" x2="53.11085" y2="71.27875" layer="21"/>
+<rectangle x1="53.22515" y1="71.26605" x2="53.47915" y2="71.27875" layer="21"/>
+<rectangle x1="54.11415" y1="71.26605" x2="54.43165" y2="71.27875" layer="21"/>
+<rectangle x1="51.19315" y1="71.27875" x2="51.48525" y2="71.29145" layer="21"/>
+<rectangle x1="51.67575" y1="71.27875" x2="52.01865" y2="71.29145" layer="21"/>
+<rectangle x1="52.52665" y1="71.27875" x2="53.08545" y2="71.29145" layer="21"/>
+<rectangle x1="53.23785" y1="71.27875" x2="53.50455" y2="71.29145" layer="21"/>
+<rectangle x1="54.08875" y1="71.27875" x2="54.41895" y2="71.29145" layer="21"/>
+<rectangle x1="51.19315" y1="71.29145" x2="51.48525" y2="71.30415" layer="21"/>
+<rectangle x1="51.66305" y1="71.29145" x2="51.99325" y2="71.30415" layer="21"/>
+<rectangle x1="52.52665" y1="71.29145" x2="53.07275" y2="71.30415" layer="21"/>
+<rectangle x1="53.26325" y1="71.29145" x2="53.52995" y2="71.30415" layer="21"/>
+<rectangle x1="54.06335" y1="71.29145" x2="54.40625" y2="71.30415" layer="21"/>
+<rectangle x1="51.20585" y1="71.30415" x2="51.49795" y2="71.31685" layer="21"/>
+<rectangle x1="51.63765" y1="71.30415" x2="51.98055" y2="71.31685" layer="21"/>
+<rectangle x1="52.53935" y1="71.30415" x2="53.07275" y2="71.31685" layer="21"/>
+<rectangle x1="53.27595" y1="71.30415" x2="53.56805" y2="71.31685" layer="21"/>
+<rectangle x1="54.03795" y1="71.30415" x2="54.39355" y2="71.31685" layer="21"/>
+<rectangle x1="51.21855" y1="71.31685" x2="51.51065" y2="71.32955" layer="21"/>
+<rectangle x1="51.62495" y1="71.31685" x2="51.98055" y2="71.32955" layer="21"/>
+<rectangle x1="52.52665" y1="71.31685" x2="53.08545" y2="71.32955" layer="21"/>
+<rectangle x1="53.28865" y1="71.31685" x2="53.60615" y2="71.32955" layer="21"/>
+<rectangle x1="54.01255" y1="71.31685" x2="54.39355" y2="71.32955" layer="21"/>
+<rectangle x1="51.21855" y1="71.32955" x2="51.52335" y2="71.34225" layer="21"/>
+<rectangle x1="51.59955" y1="71.32955" x2="51.96785" y2="71.34225" layer="21"/>
+<rectangle x1="52.52665" y1="71.32955" x2="53.08545" y2="71.34225" layer="21"/>
+<rectangle x1="53.31405" y1="71.32955" x2="53.65695" y2="71.34225" layer="21"/>
+<rectangle x1="53.97445" y1="71.32955" x2="54.38085" y2="71.34225" layer="21"/>
+<rectangle x1="51.23125" y1="71.34225" x2="51.52335" y2="71.35495" layer="21"/>
+<rectangle x1="51.58685" y1="71.34225" x2="51.95515" y2="71.35495" layer="21"/>
+<rectangle x1="52.52665" y1="71.34225" x2="53.08545" y2="71.35495" layer="21"/>
+<rectangle x1="53.32675" y1="71.34225" x2="53.74585" y2="71.35495" layer="21"/>
+<rectangle x1="53.88555" y1="71.34225" x2="54.38085" y2="71.35495" layer="21"/>
+<rectangle x1="51.23125" y1="71.35495" x2="51.53605" y2="71.36765" layer="21"/>
+<rectangle x1="51.57415" y1="71.35495" x2="51.94245" y2="71.36765" layer="21"/>
+<rectangle x1="52.52665" y1="71.35495" x2="53.08545" y2="71.36765" layer="21"/>
+<rectangle x1="53.33945" y1="71.35495" x2="54.36815" y2="71.36765" layer="21"/>
+<rectangle x1="51.24395" y1="71.36765" x2="51.94245" y2="71.38035" layer="21"/>
+<rectangle x1="52.52665" y1="71.36765" x2="53.09815" y2="71.38035" layer="21"/>
+<rectangle x1="53.36485" y1="71.36765" x2="54.36815" y2="71.38035" layer="21"/>
+<rectangle x1="51.25665" y1="71.38035" x2="51.94245" y2="71.39305" layer="21"/>
+<rectangle x1="52.52665" y1="71.38035" x2="53.09815" y2="71.39305" layer="21"/>
+<rectangle x1="53.39025" y1="71.38035" x2="54.35545" y2="71.39305" layer="21"/>
+<rectangle x1="51.25665" y1="71.39305" x2="51.95515" y2="71.40575" layer="21"/>
+<rectangle x1="52.52665" y1="71.39305" x2="53.09815" y2="71.40575" layer="21"/>
+<rectangle x1="53.41565" y1="71.39305" x2="54.34275" y2="71.40575" layer="21"/>
+<rectangle x1="51.26935" y1="71.40575" x2="51.95515" y2="71.41845" layer="21"/>
+<rectangle x1="52.51395" y1="71.40575" x2="53.09815" y2="71.41845" layer="21"/>
+<rectangle x1="53.44105" y1="71.40575" x2="54.33005" y2="71.41845" layer="21"/>
+<rectangle x1="51.28205" y1="71.41845" x2="51.95515" y2="71.43115" layer="21"/>
+<rectangle x1="52.51395" y1="71.41845" x2="53.11085" y2="71.43115" layer="21"/>
+<rectangle x1="53.46645" y1="71.41845" x2="54.33005" y2="71.43115" layer="21"/>
+<rectangle x1="51.29475" y1="71.43115" x2="51.96785" y2="71.44385" layer="21"/>
+<rectangle x1="52.51395" y1="71.43115" x2="52.75525" y2="71.44385" layer="21"/>
+<rectangle x1="52.86955" y1="71.43115" x2="53.11085" y2="71.44385" layer="21"/>
+<rectangle x1="53.49185" y1="71.43115" x2="54.31735" y2="71.44385" layer="21"/>
+<rectangle x1="51.29475" y1="71.44385" x2="51.96785" y2="71.45655" layer="21"/>
+<rectangle x1="52.50125" y1="71.44385" x2="52.74255" y2="71.45655" layer="21"/>
+<rectangle x1="52.86955" y1="71.44385" x2="53.11085" y2="71.45655" layer="21"/>
+<rectangle x1="53.54265" y1="71.44385" x2="54.30465" y2="71.45655" layer="21"/>
+<rectangle x1="51.30745" y1="71.45655" x2="51.98055" y2="71.46925" layer="21"/>
+<rectangle x1="52.50125" y1="71.45655" x2="52.74255" y2="71.46925" layer="21"/>
+<rectangle x1="52.88225" y1="71.45655" x2="53.11085" y2="71.46925" layer="21"/>
+<rectangle x1="53.58075" y1="71.45655" x2="54.29195" y2="71.46925" layer="21"/>
+<rectangle x1="51.32015" y1="71.46925" x2="51.98055" y2="71.48195" layer="21"/>
+<rectangle x1="52.50125" y1="71.46925" x2="52.74255" y2="71.48195" layer="21"/>
+<rectangle x1="52.88225" y1="71.46925" x2="53.12355" y2="71.48195" layer="21"/>
+<rectangle x1="53.63155" y1="71.46925" x2="54.27925" y2="71.48195" layer="21"/>
+<rectangle x1="51.33285" y1="71.48195" x2="51.98055" y2="71.49465" layer="21"/>
+<rectangle x1="52.50125" y1="71.48195" x2="52.72985" y2="71.49465" layer="21"/>
+<rectangle x1="52.88225" y1="71.48195" x2="53.12355" y2="71.49465" layer="21"/>
+<rectangle x1="53.63155" y1="71.48195" x2="54.26655" y2="71.49465" layer="21"/>
+<rectangle x1="51.34555" y1="71.49465" x2="51.99325" y2="71.50735" layer="21"/>
+<rectangle x1="52.48855" y1="71.49465" x2="52.72985" y2="71.50735" layer="21"/>
+<rectangle x1="52.88225" y1="71.49465" x2="53.12355" y2="71.50735" layer="21"/>
+<rectangle x1="53.61885" y1="71.49465" x2="54.25385" y2="71.50735" layer="21"/>
+<rectangle x1="51.35825" y1="71.50735" x2="51.99325" y2="71.52005" layer="21"/>
+<rectangle x1="52.48855" y1="71.50735" x2="52.72985" y2="71.52005" layer="21"/>
+<rectangle x1="52.89495" y1="71.50735" x2="53.12355" y2="71.52005" layer="21"/>
+<rectangle x1="53.61885" y1="71.50735" x2="53.87285" y2="71.52005" layer="21"/>
+<rectangle x1="53.88555" y1="71.50735" x2="54.24115" y2="71.52005" layer="21"/>
+<rectangle x1="51.35825" y1="71.52005" x2="51.72655" y2="71.53275" layer="21"/>
+<rectangle x1="51.75195" y1="71.52005" x2="52.00595" y2="71.53275" layer="21"/>
+<rectangle x1="52.48855" y1="71.52005" x2="52.72985" y2="71.53275" layer="21"/>
+<rectangle x1="52.89495" y1="71.52005" x2="53.13625" y2="71.53275" layer="21"/>
+<rectangle x1="53.60615" y1="71.52005" x2="53.86015" y2="71.53275" layer="21"/>
+<rectangle x1="53.89825" y1="71.52005" x2="54.22845" y2="71.53275" layer="21"/>
+<rectangle x1="51.37095" y1="71.53275" x2="51.70115" y2="71.54545" layer="21"/>
+<rectangle x1="51.76465" y1="71.53275" x2="52.00595" y2="71.54545" layer="21"/>
+<rectangle x1="52.47585" y1="71.53275" x2="52.71715" y2="71.54545" layer="21"/>
+<rectangle x1="52.90765" y1="71.53275" x2="53.13625" y2="71.54545" layer="21"/>
+<rectangle x1="53.60615" y1="71.53275" x2="53.86015" y2="71.54545" layer="21"/>
+<rectangle x1="53.92365" y1="71.53275" x2="54.21575" y2="71.54545" layer="21"/>
+<rectangle x1="51.38365" y1="71.54545" x2="51.67575" y2="71.55815" layer="21"/>
+<rectangle x1="51.76465" y1="71.54545" x2="52.01865" y2="71.55815" layer="21"/>
+<rectangle x1="52.47585" y1="71.54545" x2="52.71715" y2="71.55815" layer="21"/>
+<rectangle x1="52.90765" y1="71.54545" x2="53.14895" y2="71.55815" layer="21"/>
+<rectangle x1="53.59345" y1="71.54545" x2="53.86015" y2="71.55815" layer="21"/>
+<rectangle x1="53.94905" y1="71.54545" x2="54.20305" y2="71.55815" layer="21"/>
+<rectangle x1="51.39635" y1="71.55815" x2="51.66305" y2="71.57085" layer="21"/>
+<rectangle x1="51.76465" y1="71.55815" x2="52.01865" y2="71.57085" layer="21"/>
+<rectangle x1="52.47585" y1="71.55815" x2="52.71715" y2="71.57085" layer="21"/>
+<rectangle x1="52.90765" y1="71.55815" x2="53.14895" y2="71.57085" layer="21"/>
+<rectangle x1="53.59345" y1="71.55815" x2="53.84745" y2="71.57085" layer="21"/>
+<rectangle x1="53.96175" y1="71.55815" x2="54.19035" y2="71.57085" layer="21"/>
+<rectangle x1="51.42175" y1="71.57085" x2="51.63765" y2="71.58355" layer="21"/>
+<rectangle x1="51.77735" y1="71.57085" x2="52.03135" y2="71.58355" layer="21"/>
+<rectangle x1="52.46315" y1="71.57085" x2="52.70445" y2="71.58355" layer="21"/>
+<rectangle x1="52.90765" y1="71.57085" x2="53.16165" y2="71.58355" layer="21"/>
+<rectangle x1="53.58075" y1="71.57085" x2="53.83475" y2="71.58355" layer="21"/>
+<rectangle x1="53.98715" y1="71.57085" x2="54.17765" y2="71.58355" layer="21"/>
+<rectangle x1="51.43445" y1="71.58355" x2="51.61225" y2="71.59625" layer="21"/>
+<rectangle x1="51.77735" y1="71.58355" x2="52.03135" y2="71.59625" layer="21"/>
+<rectangle x1="52.46315" y1="71.58355" x2="52.70445" y2="71.59625" layer="21"/>
+<rectangle x1="52.92035" y1="71.58355" x2="53.16165" y2="71.59625" layer="21"/>
+<rectangle x1="53.58075" y1="71.58355" x2="53.83475" y2="71.59625" layer="21"/>
+<rectangle x1="54.01255" y1="71.58355" x2="54.16495" y2="71.59625" layer="21"/>
+<rectangle x1="51.47255" y1="71.59625" x2="51.57415" y2="71.60895" layer="21"/>
+<rectangle x1="51.79005" y1="71.59625" x2="52.04405" y2="71.60895" layer="21"/>
+<rectangle x1="52.45045" y1="71.59625" x2="52.69175" y2="71.60895" layer="21"/>
+<rectangle x1="52.92035" y1="71.59625" x2="53.17435" y2="71.60895" layer="21"/>
+<rectangle x1="53.56805" y1="71.59625" x2="53.82205" y2="71.60895" layer="21"/>
+<rectangle x1="54.03795" y1="71.59625" x2="54.12685" y2="71.60895" layer="21"/>
+<rectangle x1="51.79005" y1="71.60895" x2="52.05675" y2="71.62165" layer="21"/>
+<rectangle x1="52.45045" y1="71.60895" x2="52.69175" y2="71.62165" layer="21"/>
+<rectangle x1="52.93305" y1="71.60895" x2="53.17435" y2="71.62165" layer="21"/>
+<rectangle x1="53.56805" y1="71.60895" x2="53.82205" y2="71.62165" layer="21"/>
+<rectangle x1="51.80275" y1="71.62165" x2="52.05675" y2="71.63435" layer="21"/>
+<rectangle x1="52.43775" y1="71.62165" x2="52.69175" y2="71.63435" layer="21"/>
+<rectangle x1="52.93305" y1="71.62165" x2="53.17435" y2="71.63435" layer="21"/>
+<rectangle x1="53.55535" y1="71.62165" x2="53.82205" y2="71.63435" layer="21"/>
+<rectangle x1="51.80275" y1="71.63435" x2="52.06945" y2="71.64705" layer="21"/>
+<rectangle x1="52.43775" y1="71.63435" x2="52.67905" y2="71.64705" layer="21"/>
+<rectangle x1="52.93305" y1="71.63435" x2="53.18705" y2="71.64705" layer="21"/>
+<rectangle x1="53.54265" y1="71.63435" x2="53.80935" y2="71.64705" layer="21"/>
+<rectangle x1="51.81545" y1="71.64705" x2="52.06945" y2="71.65975" layer="21"/>
+<rectangle x1="52.42505" y1="71.64705" x2="52.67905" y2="71.65975" layer="21"/>
+<rectangle x1="52.94575" y1="71.64705" x2="53.18705" y2="71.65975" layer="21"/>
+<rectangle x1="53.54265" y1="71.64705" x2="53.80935" y2="71.65975" layer="21"/>
+<rectangle x1="51.81545" y1="71.65975" x2="52.08215" y2="71.67245" layer="21"/>
+<rectangle x1="52.42505" y1="71.65975" x2="52.67905" y2="71.67245" layer="21"/>
+<rectangle x1="52.94575" y1="71.65975" x2="53.19975" y2="71.67245" layer="21"/>
+<rectangle x1="53.52995" y1="71.65975" x2="53.79665" y2="71.67245" layer="21"/>
+<rectangle x1="51.82815" y1="71.67245" x2="52.09485" y2="71.68515" layer="21"/>
+<rectangle x1="52.41235" y1="71.67245" x2="52.66635" y2="71.68515" layer="21"/>
+<rectangle x1="52.95845" y1="71.67245" x2="53.19975" y2="71.68515" layer="21"/>
+<rectangle x1="53.52995" y1="71.67245" x2="53.79665" y2="71.68515" layer="21"/>
+<rectangle x1="51.82815" y1="71.68515" x2="52.09485" y2="71.69785" layer="21"/>
+<rectangle x1="52.41235" y1="71.68515" x2="52.66635" y2="71.69785" layer="21"/>
+<rectangle x1="52.95845" y1="71.68515" x2="53.21245" y2="71.69785" layer="21"/>
+<rectangle x1="53.51725" y1="71.68515" x2="53.78395" y2="71.69785" layer="21"/>
+<rectangle x1="51.84085" y1="71.69785" x2="52.10755" y2="71.71055" layer="21"/>
+<rectangle x1="52.39965" y1="71.69785" x2="52.66635" y2="71.71055" layer="21"/>
+<rectangle x1="52.95845" y1="71.69785" x2="53.22515" y2="71.71055" layer="21"/>
+<rectangle x1="53.50455" y1="71.69785" x2="53.77125" y2="71.71055" layer="21"/>
+<rectangle x1="51.84085" y1="71.71055" x2="52.12025" y2="71.72325" layer="21"/>
+<rectangle x1="52.39965" y1="71.71055" x2="52.65365" y2="71.72325" layer="21"/>
+<rectangle x1="52.97115" y1="71.71055" x2="53.22515" y2="71.72325" layer="21"/>
+<rectangle x1="53.49185" y1="71.71055" x2="53.77125" y2="71.72325" layer="21"/>
+<rectangle x1="51.85355" y1="71.72325" x2="52.12025" y2="71.73595" layer="21"/>
+<rectangle x1="52.38695" y1="71.72325" x2="52.64095" y2="71.73595" layer="21"/>
+<rectangle x1="52.97115" y1="71.72325" x2="53.23785" y2="71.73595" layer="21"/>
+<rectangle x1="53.49185" y1="71.72325" x2="53.75855" y2="71.73595" layer="21"/>
+<rectangle x1="51.86625" y1="71.73595" x2="52.13295" y2="71.74865" layer="21"/>
+<rectangle x1="52.37425" y1="71.73595" x2="52.64095" y2="71.74865" layer="21"/>
+<rectangle x1="52.98385" y1="71.73595" x2="53.25055" y2="71.74865" layer="21"/>
+<rectangle x1="53.47915" y1="71.73595" x2="53.75855" y2="71.74865" layer="21"/>
+<rectangle x1="51.86625" y1="71.74865" x2="52.14565" y2="71.76135" layer="21"/>
+<rectangle x1="52.37425" y1="71.74865" x2="52.62825" y2="71.76135" layer="21"/>
+<rectangle x1="52.98385" y1="71.74865" x2="53.26325" y2="71.76135" layer="21"/>
+<rectangle x1="53.46645" y1="71.74865" x2="53.74585" y2="71.76135" layer="21"/>
+<rectangle x1="51.87895" y1="71.76135" x2="52.15835" y2="71.77405" layer="21"/>
+<rectangle x1="52.36155" y1="71.76135" x2="52.62825" y2="71.77405" layer="21"/>
+<rectangle x1="52.99655" y1="71.76135" x2="53.26325" y2="71.77405" layer="21"/>
+<rectangle x1="53.46645" y1="71.76135" x2="53.73315" y2="71.77405" layer="21"/>
+<rectangle x1="51.87895" y1="71.77405" x2="52.17105" y2="71.78675" layer="21"/>
+<rectangle x1="52.34885" y1="71.77405" x2="52.61555" y2="71.78675" layer="21"/>
+<rectangle x1="52.99655" y1="71.77405" x2="53.27595" y2="71.78675" layer="21"/>
+<rectangle x1="53.45375" y1="71.77405" x2="53.73315" y2="71.78675" layer="21"/>
+<rectangle x1="51.89165" y1="71.78675" x2="52.18375" y2="71.79945" layer="21"/>
+<rectangle x1="52.33615" y1="71.78675" x2="52.61555" y2="71.79945" layer="21"/>
+<rectangle x1="53.00925" y1="71.78675" x2="53.28865" y2="71.79945" layer="21"/>
+<rectangle x1="53.42835" y1="71.78675" x2="53.72045" y2="71.79945" layer="21"/>
+<rectangle x1="51.90435" y1="71.79945" x2="52.19645" y2="71.81215" layer="21"/>
+<rectangle x1="52.32345" y1="71.79945" x2="52.60285" y2="71.81215" layer="21"/>
+<rectangle x1="53.02195" y1="71.79945" x2="53.30135" y2="71.81215" layer="21"/>
+<rectangle x1="53.41565" y1="71.79945" x2="53.70775" y2="71.81215" layer="21"/>
+<rectangle x1="51.90435" y1="71.81215" x2="52.20915" y2="71.82485" layer="21"/>
+<rectangle x1="52.32345" y1="71.81215" x2="52.60285" y2="71.82485" layer="21"/>
+<rectangle x1="53.02195" y1="71.81215" x2="53.30135" y2="71.82485" layer="21"/>
+<rectangle x1="53.41565" y1="71.81215" x2="53.70775" y2="71.82485" layer="21"/>
+<rectangle x1="51.91705" y1="71.82485" x2="52.22185" y2="71.83755" layer="21"/>
+<rectangle x1="52.31075" y1="71.82485" x2="52.59015" y2="71.83755" layer="21"/>
+<rectangle x1="53.03465" y1="71.82485" x2="53.31405" y2="71.83755" layer="21"/>
+<rectangle x1="53.39025" y1="71.82485" x2="53.69505" y2="71.83755" layer="21"/>
+<rectangle x1="51.92975" y1="71.83755" x2="52.23455" y2="71.85025" layer="21"/>
+<rectangle x1="52.29805" y1="71.83755" x2="52.57745" y2="71.85025" layer="21"/>
+<rectangle x1="53.03465" y1="71.83755" x2="53.32675" y2="71.85025" layer="21"/>
+<rectangle x1="53.37755" y1="71.83755" x2="53.68235" y2="71.85025" layer="21"/>
+<rectangle x1="51.92975" y1="71.85025" x2="52.23455" y2="71.86295" layer="21"/>
+<rectangle x1="52.28535" y1="71.85025" x2="52.57745" y2="71.86295" layer="21"/>
+<rectangle x1="53.04735" y1="71.85025" x2="53.33945" y2="71.86295" layer="21"/>
+<rectangle x1="53.37755" y1="71.85025" x2="53.68235" y2="71.86295" layer="21"/>
+<rectangle x1="51.94245" y1="71.86295" x2="52.25995" y2="71.87565" layer="21"/>
+<rectangle x1="52.27265" y1="71.86295" x2="52.56475" y2="71.87565" layer="21"/>
+<rectangle x1="53.06005" y1="71.86295" x2="53.66965" y2="71.87565" layer="21"/>
+<rectangle x1="51.95515" y1="71.87565" x2="52.56475" y2="71.88835" layer="21"/>
+<rectangle x1="53.07275" y1="71.87565" x2="53.65695" y2="71.88835" layer="21"/>
+<rectangle x1="51.96785" y1="71.88835" x2="52.55205" y2="71.90105" layer="21"/>
+<rectangle x1="53.07275" y1="71.88835" x2="53.64425" y2="71.90105" layer="21"/>
+<rectangle x1="51.96785" y1="71.90105" x2="52.53935" y2="71.91375" layer="21"/>
+<rectangle x1="53.08545" y1="71.90105" x2="53.64425" y2="71.91375" layer="21"/>
+<rectangle x1="51.98055" y1="71.91375" x2="52.52665" y2="71.92645" layer="21"/>
+<rectangle x1="53.09815" y1="71.91375" x2="53.63155" y2="71.92645" layer="21"/>
+<rectangle x1="51.99325" y1="71.92645" x2="52.52665" y2="71.93915" layer="21"/>
+<rectangle x1="53.09815" y1="71.92645" x2="53.61885" y2="71.93915" layer="21"/>
+<rectangle x1="52.00595" y1="71.93915" x2="52.52665" y2="71.95185" layer="21"/>
+<rectangle x1="53.11085" y1="71.93915" x2="53.60615" y2="71.95185" layer="21"/>
+<rectangle x1="52.01865" y1="71.95185" x2="52.53935" y2="71.96455" layer="21"/>
+<rectangle x1="53.09815" y1="71.95185" x2="53.59345" y2="71.96455" layer="21"/>
+<rectangle x1="52.03135" y1="71.96455" x2="52.53935" y2="71.97725" layer="21"/>
+<rectangle x1="53.09815" y1="71.96455" x2="53.58075" y2="71.97725" layer="21"/>
+<rectangle x1="52.04405" y1="71.97725" x2="52.56475" y2="71.98995" layer="21"/>
+<rectangle x1="53.08545" y1="71.97725" x2="53.56805" y2="71.98995" layer="21"/>
+<rectangle x1="52.05675" y1="71.98995" x2="52.56475" y2="72.00265" layer="21"/>
+<rectangle x1="53.07275" y1="71.98995" x2="53.55535" y2="72.00265" layer="21"/>
+<rectangle x1="52.06945" y1="72.00265" x2="52.57745" y2="72.01535" layer="21"/>
+<rectangle x1="53.06005" y1="72.00265" x2="53.54265" y2="72.01535" layer="21"/>
+<rectangle x1="52.08215" y1="72.01535" x2="52.59015" y2="72.02805" layer="21"/>
+<rectangle x1="53.06005" y1="72.01535" x2="53.52995" y2="72.02805" layer="21"/>
+<rectangle x1="52.09485" y1="72.02805" x2="52.60285" y2="72.04075" layer="21"/>
+<rectangle x1="53.03465" y1="72.02805" x2="53.51725" y2="72.04075" layer="21"/>
+<rectangle x1="52.12025" y1="72.04075" x2="52.61555" y2="72.05345" layer="21"/>
+<rectangle x1="53.03465" y1="72.04075" x2="53.49185" y2="72.05345" layer="21"/>
+<rectangle x1="52.12025" y1="72.05345" x2="52.61555" y2="72.06615" layer="21"/>
+<rectangle x1="53.02195" y1="72.05345" x2="53.49185" y2="72.06615" layer="21"/>
+<rectangle x1="52.14565" y1="72.06615" x2="52.62825" y2="72.07885" layer="21"/>
+<rectangle x1="53.00925" y1="72.06615" x2="53.46645" y2="72.07885" layer="21"/>
+<rectangle x1="52.15835" y1="72.07885" x2="52.64095" y2="72.09155" layer="21"/>
+<rectangle x1="52.99655" y1="72.07885" x2="53.45375" y2="72.09155" layer="21"/>
+<rectangle x1="52.18375" y1="72.09155" x2="52.66635" y2="72.10425" layer="21"/>
+<rectangle x1="52.98385" y1="72.09155" x2="53.42835" y2="72.10425" layer="21"/>
+<rectangle x1="52.20915" y1="72.10425" x2="52.67905" y2="72.11695" layer="21"/>
+<rectangle x1="52.97115" y1="72.10425" x2="53.41565" y2="72.11695" layer="21"/>
+<rectangle x1="52.22185" y1="72.11695" x2="52.69175" y2="72.12965" layer="21"/>
+<rectangle x1="52.95845" y1="72.11695" x2="53.39025" y2="72.12965" layer="21"/>
+<rectangle x1="52.23455" y1="72.12965" x2="52.37425" y2="72.14235" layer="21"/>
+<rectangle x1="52.38695" y1="72.12965" x2="52.70445" y2="72.14235" layer="21"/>
+<rectangle x1="52.93305" y1="72.12965" x2="53.37755" y2="72.14235" layer="21"/>
+<rectangle x1="52.27265" y1="72.14235" x2="52.37425" y2="72.15505" layer="21"/>
+<rectangle x1="52.39965" y1="72.14235" x2="52.72985" y2="72.15505" layer="21"/>
+<rectangle x1="52.92035" y1="72.14235" x2="53.35215" y2="72.15505" layer="21"/>
+<rectangle x1="52.28535" y1="72.15505" x2="52.37425" y2="72.16775" layer="21"/>
+<rectangle x1="52.39965" y1="72.15505" x2="52.72985" y2="72.16775" layer="21"/>
+<rectangle x1="52.90765" y1="72.15505" x2="53.32675" y2="72.16775" layer="21"/>
+<rectangle x1="52.31075" y1="72.16775" x2="52.36155" y2="72.18045" layer="21"/>
+<rectangle x1="52.41235" y1="72.16775" x2="52.75525" y2="72.18045" layer="21"/>
+<rectangle x1="52.88225" y1="72.16775" x2="53.22515" y2="72.18045" layer="21"/>
+<rectangle x1="53.25055" y1="72.16775" x2="53.30135" y2="72.18045" layer="21"/>
+<rectangle x1="52.33615" y1="72.18045" x2="52.36155" y2="72.19315" layer="21"/>
+<rectangle x1="52.42505" y1="72.18045" x2="52.78065" y2="72.19315" layer="21"/>
+<rectangle x1="52.86955" y1="72.18045" x2="53.21245" y2="72.19315" layer="21"/>
+<rectangle x1="53.25055" y1="72.18045" x2="53.27595" y2="72.19315" layer="21"/>
+<rectangle x1="52.43775" y1="72.19315" x2="52.79335" y2="72.20585" layer="21"/>
+<rectangle x1="52.84415" y1="72.19315" x2="53.19975" y2="72.20585" layer="21"/>
+<rectangle x1="52.45045" y1="72.20585" x2="53.18705" y2="72.21855" layer="21"/>
+<rectangle x1="52.46315" y1="72.21855" x2="53.17435" y2="72.23125" layer="21"/>
+<rectangle x1="52.47585" y1="72.23125" x2="53.16165" y2="72.24395" layer="21"/>
+<rectangle x1="52.48855" y1="72.24395" x2="53.14895" y2="72.25665" layer="21"/>
+<rectangle x1="52.50125" y1="72.25665" x2="53.13625" y2="72.26935" layer="21"/>
+<rectangle x1="52.51395" y1="72.26935" x2="53.12355" y2="72.28205" layer="21"/>
+<rectangle x1="52.52665" y1="72.28205" x2="53.11085" y2="72.29475" layer="21"/>
+<rectangle x1="52.55205" y1="72.29475" x2="53.09815" y2="72.30745" layer="21"/>
+<rectangle x1="52.56475" y1="72.30745" x2="53.08545" y2="72.32015" layer="21"/>
+<rectangle x1="52.57745" y1="72.32015" x2="53.06005" y2="72.33285" layer="21"/>
+<rectangle x1="52.59015" y1="72.33285" x2="53.04735" y2="72.34555" layer="21"/>
+<rectangle x1="52.61555" y1="72.34555" x2="53.03465" y2="72.35825" layer="21"/>
+<rectangle x1="52.62825" y1="72.35825" x2="53.02195" y2="72.37095" layer="21"/>
+<rectangle x1="52.64095" y1="72.37095" x2="52.99655" y2="72.38365" layer="21"/>
+<rectangle x1="52.66635" y1="72.38365" x2="52.97115" y2="72.39635" layer="21"/>
+<rectangle x1="52.67905" y1="72.39635" x2="52.95845" y2="72.40905" layer="21"/>
+<rectangle x1="52.70445" y1="72.40905" x2="52.93305" y2="72.42175" layer="21"/>
+<rectangle x1="52.72985" y1="72.42175" x2="52.92035" y2="72.43445" layer="21"/>
+<rectangle x1="52.75525" y1="72.43445" x2="52.88225" y2="72.44715" layer="21"/>
+<text x="41.1" y="65.4" size="0.8128" layer="21" ratio="1">https://www.fermentrack.com/</text>
+</plain>
+<libraries>
+<library name="1455413453956-wemos">
+<packages>
+<package name="WEMOS">
+<description>WEMOS Controller socket</description>
+<pad name="3V3" x="0" y="0" drill="0.8" shape="octagon"/>
+<pad name="D8" x="0" y="2.54" drill="0.8" shape="octagon"/>
+<pad name="D7" x="0" y="5.08" drill="0.8" shape="octagon"/>
+<pad name="D6" x="0" y="7.62" drill="0.8" shape="octagon"/>
+<pad name="D5" x="0" y="10.16" drill="0.8" shape="octagon"/>
+<pad name="D0" x="0" y="12.7" drill="0.8" shape="octagon"/>
+<pad name="A0" x="0" y="15.24" drill="0.8" shape="octagon"/>
+<pad name="RST" x="0" y="17.78" drill="0.8" shape="octagon"/>
+<pad name="5V" x="22.86" y="0" drill="0.8" shape="octagon"/>
+<pad name="GND" x="22.86" y="2.54" drill="0.8" shape="octagon"/>
+<pad name="D4" x="22.86" y="5.08" drill="0.8" shape="octagon"/>
+<pad name="D3" x="22.86" y="7.62" drill="0.8" shape="octagon"/>
+<pad name="D2" x="22.86" y="10.16" drill="0.8" shape="octagon"/>
+<pad name="D1" x="22.86" y="12.7" drill="0.8" shape="octagon"/>
+<pad name="RX" x="22.86" y="15.24" drill="0.8" shape="octagon"/>
+<pad name="TX" x="22.86" y="17.78" drill="0.8" shape="octagon"/>
+<rectangle x1="-1.27" y1="-1.27" x2="1.27" y2="19.05" layer="21"/>
+<rectangle x1="21.59" y1="-1.27" x2="24.13" y2="19.05" layer="21"/>
+<text x="8.89" y="19.05" size="0.8128" layer="21" font="vector"> WEMOS
+Controller</text>
+<wire x1="2" y1="-9" x2="25" y2="-9" width="0.127" layer="21"/>
+<wire x1="25" y1="-9" x2="25" y2="24" width="0.127" layer="21"/>
+<wire x1="22" y1="27" x2="1" y2="27" width="0.127" layer="21"/>
+<text x="7.635" y="23.54" size="0.8128" layer="21" font="vector">Radio Antenna
+  Facing UP</text>
+<text x="7.635" y="-7.43" size="0.8128" layer="21" font="vector">   USB bottom
+Facing DOWN/PCB</text>
+<wire x1="-2" y1="24" x2="-2" y2="-2" width="0.127" layer="21"/>
+<wire x1="-2" y1="24" x2="1" y2="27" width="0.127" layer="21" curve="-90"/>
+<wire x1="25" y1="24" x2="22" y2="27" width="0.127" layer="21" curve="90"/>
+<wire x1="2" y1="-9" x2="2" y2="-4" width="0.127" layer="21"/>
+<wire x1="2" y1="-4" x2="-2" y2="-2" width="0.127" layer="21"/>
+<text x="1.905" y="-0.635" size="1.27" layer="21" font="vector">3V3</text>
+<text x="1.905" y="1.905" size="1.27" layer="21" font="vector">D8</text>
+<text x="1.905" y="4.445" size="1.27" layer="21" font="vector">D7</text>
+<text x="1.905" y="6.985" size="1.27" layer="21" font="vector">D6</text>
+<text x="1.905" y="9.525" size="1.27" layer="21" font="vector">D5</text>
+<text x="1.905" y="12.065" size="1.27" layer="21" font="vector">D0</text>
+<text x="1.905" y="14.605" size="1.27" layer="21" font="vector">A0</text>
+<text x="1.905" y="17.145" size="1.27" layer="21" font="vector">RST</text>
+<text x="19.05" y="-0.635" size="1.27" layer="21" font="vector">5V</text>
+<text x="17.78" y="1.905" size="1.27" layer="21" font="vector">GND</text>
+<text x="19.05" y="4.445" size="1.27" layer="21" font="vector">D4</text>
+<text x="19.05" y="6.985" size="1.27" layer="21" font="vector">D3</text>
+<text x="19.05" y="9.525" size="1.27" layer="21" font="vector">D2</text>
+<text x="19.05" y="12.065" size="1.27" layer="21" font="vector">D1</text>
+<text x="19.05" y="14.605" size="1.27" layer="21" font="vector">RX</text>
+<text x="19.05" y="17.145" size="1.27" layer="21" font="vector">TX</text>
+</package>
+</packages>
+</library>
+<library name="con-wago-500">
+<description>&lt;b&gt;Wago Screw Clamps&lt;/b&gt;&lt;p&gt;
+Grid 5.00 mm&lt;p&gt;
+&lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
+<packages>
+<package name="W237-102">
+<description>&lt;b&gt;WAGO SCREW CLAMP&lt;/b&gt;</description>
+<wire x1="-3.491" y1="-2.286" x2="-1.484" y2="-0.279" width="0.254" layer="51"/>
+<wire x1="1.488" y1="-2.261" x2="3.469" y2="-0.254" width="0.254" layer="51"/>
+<wire x1="-4.989" y1="-5.461" x2="4.993" y2="-5.461" width="0.1524" layer="21"/>
+<wire x1="4.993" y1="3.734" x2="4.993" y2="3.531" width="0.1524" layer="21"/>
+<wire x1="4.993" y1="3.734" x2="-4.989" y2="3.734" width="0.1524" layer="21"/>
+<wire x1="-4.989" y1="-5.461" x2="-4.989" y2="-3.073" width="0.1524" layer="21"/>
+<wire x1="-4.989" y1="-3.073" x2="-3.389" y2="-3.073" width="0.1524" layer="21"/>
+<wire x1="-3.389" y1="-3.073" x2="-1.611" y2="-3.073" width="0.1524" layer="51"/>
+<wire x1="-1.611" y1="-3.073" x2="1.615" y2="-3.073" width="0.1524" layer="21"/>
+<wire x1="3.393" y1="-3.073" x2="4.993" y2="-3.073" width="0.1524" layer="21"/>
+<wire x1="-4.989" y1="-3.073" x2="-4.989" y2="3.531" width="0.1524" layer="21"/>
+<wire x1="4.993" y1="-3.073" x2="4.993" y2="-5.461" width="0.1524" layer="21"/>
+<wire x1="-4.989" y1="3.531" x2="4.993" y2="3.531" width="0.1524" layer="21"/>
+<wire x1="-4.989" y1="3.531" x2="-4.989" y2="3.734" width="0.1524" layer="21"/>
+<wire x1="4.993" y1="3.531" x2="4.993" y2="-3.073" width="0.1524" layer="21"/>
+<wire x1="1.615" y1="-3.073" x2="3.393" y2="-3.073" width="0.1524" layer="51"/>
+<circle x="-2.5" y="-1.27" radius="1.4986" width="0.1524" layer="51"/>
+<circle x="-2.5" y="2.2098" radius="0.508" width="0.1524" layer="21"/>
+<circle x="2.5038" y="-1.27" radius="1.4986" width="0.1524" layer="51"/>
+<circle x="2.5038" y="2.2098" radius="0.508" width="0.1524" layer="21"/>
+<pad name="1" x="-2.5" y="-1.27" drill="1.1938" shape="long" rot="R90"/>
+<pad name="2" x="2.5" y="-1.27" drill="1.1938" shape="long" rot="R90"/>
+<text x="-5.04" y="-7.62" size="1.27" layer="27" ratio="10">&gt;VALUE</text>
+<text x="-3.8462" y="-5.0038" size="1.27" layer="25" ratio="10">&gt;NAME</text>
+<text x="-4.532" y="0.635" size="1.27" layer="21" ratio="10">1</text>
+<text x="0.421" y="0.635" size="1.27" layer="21" ratio="10">2</text>
+</package>
+</packages>
+</library>
+<library name="con-tycoelectronics">
+<description>&lt;b&gt;Tyco Electronics Connector&lt;/b&gt;&lt;p&gt;
+http://catalog.tycoelectronics.com&lt;br&gt;
+&lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
+<packages>
+<package name="RJ45-NO-SHIELD-NOLINE">
+<description>&lt;b&gt;RJ45 Low Profile&lt;/b&gt; No Shield&lt;p&gt;
+For all RJ45 N and Z Series Models&lt;br&gt;
+Source: www.tycoelectronics.com .. ENG_DS_1654001_1099_RJ_L_0507.pdf</description>
+<wire x1="-7.527" y1="10.819" x2="7.527" y2="10.819" width="0.2032" layer="21"/>
+<wire x1="7.527" y1="-7.782" x2="-7.527" y2="-7.782" width="0.2032" layer="21"/>
+<wire x1="-7.527" y1="-7.782" x2="-7.527" y2="10.819" width="0.2032" layer="21"/>
+<wire x1="7.527" y1="10.819" x2="7.527" y2="-7.782" width="0.2032" layer="21"/>
+<pad name="4" x="-0.635" y="8.89" drill="0.9" diameter="1.4"/>
+<pad name="3" x="-1.905" y="6.35" drill="0.9" diameter="1.4"/>
+<pad name="2" x="-3.175" y="8.89" drill="0.9" diameter="1.4"/>
+<pad name="5" x="0.635" y="6.35" drill="0.9" diameter="1.4"/>
+<pad name="1" x="-4.445" y="6.35" drill="0.9" diameter="1.4"/>
+<pad name="6" x="1.905" y="8.89" drill="0.9" diameter="1.4"/>
+<pad name="7" x="3.175" y="6.35" drill="0.9" diameter="1.4"/>
+<pad name="8" x="4.445" y="8.89" drill="0.9" diameter="1.4"/>
+<text x="-9.525" y="-0.635" size="1.778" layer="25" rot="R90">&gt;NAME</text>
+<text x="-5.715" y="2.54" size="1.778" layer="27">&gt;VALUE</text>
+<rectangle x1="7.6" y1="-5.485" x2="8.875" y2="-4.342" layer="21"/>
+<rectangle x1="-8.875" y1="-5.485" x2="-7.625" y2="-4.342" layer="21"/>
+<hole x="-5.715" y="0" drill="3.2512"/>
+<hole x="5.715" y="0" drill="3.2512"/>
+</package>
+</packages>
+</library>
+<library name="holes">
+<description>&lt;b&gt;Mounting Holes and Pads&lt;/b&gt;&lt;p&gt;
+&lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
+<packages>
+<package name="3,0">
+<description>&lt;b&gt;MOUNTING HOLE&lt;/b&gt; 3.0 mm with drill center</description>
+<wire x1="-2.159" y1="0" x2="0" y2="-2.159" width="2.4892" layer="51" curve="90" cap="flat"/>
+<wire x1="0" y1="2.159" x2="2.159" y2="0" width="2.4892" layer="51" curve="-90" cap="flat"/>
+<circle x="0" y="0" radius="3.429" width="0.1524" layer="21"/>
+<circle x="0" y="0" radius="0.762" width="0.4572" layer="51"/>
+<circle x="0" y="0" radius="3.048" width="2.032" layer="39"/>
+<circle x="0" y="0" radius="3.048" width="2.032" layer="43"/>
+<circle x="0" y="0" radius="3.048" width="2.032" layer="40"/>
+<circle x="0" y="0" radius="3.048" width="2.032" layer="41"/>
+<circle x="0" y="0" radius="3.048" width="2.032" layer="42"/>
+<circle x="0" y="0" radius="1.6" width="0.2032" layer="21"/>
+<text x="-1.27" y="-3.81" size="1.27" layer="48">3,0</text>
+<hole x="0" y="0" drill="3"/>
+</package>
+</packages>
+</library>
+<library name="pinhead">
+<description>&lt;b&gt;Pin Header Connectors&lt;/b&gt;&lt;p&gt;
+&lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
+<packages>
+<package name="1X02">
+<description>&lt;b&gt;PIN HEADER&lt;/b&gt;</description>
+<wire x1="-1.905" y1="1.27" x2="-0.635" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="-0.635" y1="1.27" x2="0" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="0" y1="0.635" x2="0" y2="-0.635" width="0.1524" layer="21"/>
+<wire x1="0" y1="-0.635" x2="-0.635" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="-2.54" y1="0.635" x2="-2.54" y2="-0.635" width="0.1524" layer="21"/>
+<wire x1="-1.905" y1="1.27" x2="-2.54" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="-2.54" y1="-0.635" x2="-1.905" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="-0.635" y1="-1.27" x2="-1.905" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="0" y1="0.635" x2="0.635" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="0.635" y1="1.27" x2="1.905" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="1.905" y1="1.27" x2="2.54" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="2.54" y1="0.635" x2="2.54" y2="-0.635" width="0.1524" layer="21"/>
+<wire x1="2.54" y1="-0.635" x2="1.905" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="1.905" y1="-1.27" x2="0.635" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="0.635" y1="-1.27" x2="0" y2="-0.635" width="0.1524" layer="21"/>
+<pad name="1" x="-1.27" y="0" drill="1.016" shape="long" rot="R90"/>
+<pad name="2" x="1.27" y="0" drill="1.016" shape="long" rot="R90"/>
+<text x="-2.6162" y="1.8288" size="1.27" layer="25" ratio="10">&gt;NAME</text>
+<text x="-2.54" y="-3.175" size="1.27" layer="27">&gt;VALUE</text>
+<rectangle x1="-1.524" y1="-0.254" x2="-1.016" y2="0.254" layer="51"/>
+<rectangle x1="1.016" y1="-0.254" x2="1.524" y2="0.254" layer="51"/>
+</package>
+</packages>
+</library>
+<library name="con-lstb">
+<description>&lt;b&gt;Pin Headers&lt;/b&gt;&lt;p&gt;
+Naming:&lt;p&gt;
+MA = male&lt;p&gt;
+# contacts - # rows&lt;p&gt;
+W = angled&lt;p&gt;
+&lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
+<packages>
+<package name="MA04-1">
+<description>&lt;b&gt;PIN HEADER&lt;/b&gt;</description>
+<wire x1="-4.445" y1="1.27" x2="-3.175" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="-3.175" y1="1.27" x2="-2.54" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="-2.54" y1="-0.635" x2="-3.175" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="-2.54" y1="0.635" x2="-1.905" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="-1.905" y1="1.27" x2="-0.635" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="-0.635" y1="1.27" x2="0" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="0" y1="-0.635" x2="-0.635" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="-0.635" y1="-1.27" x2="-1.905" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="-1.905" y1="-1.27" x2="-2.54" y2="-0.635" width="0.1524" layer="21"/>
+<wire x1="-5.08" y1="0.635" x2="-5.08" y2="-0.635" width="0.1524" layer="21"/>
+<wire x1="-4.445" y1="1.27" x2="-5.08" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="-5.08" y1="-0.635" x2="-4.445" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="-3.175" y1="-1.27" x2="-4.445" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="0" y1="0.635" x2="0.635" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="0.635" y1="1.27" x2="1.905" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="1.905" y1="1.27" x2="2.54" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="2.54" y1="-0.635" x2="1.905" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="1.905" y1="-1.27" x2="0.635" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="0.635" y1="-1.27" x2="0" y2="-0.635" width="0.1524" layer="21"/>
+<wire x1="3.175" y1="1.27" x2="4.445" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="4.445" y1="1.27" x2="5.08" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="5.08" y1="0.635" x2="5.08" y2="-0.635" width="0.1524" layer="21"/>
+<wire x1="5.08" y1="-0.635" x2="4.445" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="3.175" y1="1.27" x2="2.54" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="2.54" y1="-0.635" x2="3.175" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="4.445" y1="-1.27" x2="3.175" y2="-1.27" width="0.1524" layer="21"/>
+<pad name="1" x="-3.81" y="0" drill="1.016" shape="long" rot="R90"/>
+<pad name="2" x="-1.27" y="0" drill="1.016" shape="long" rot="R90"/>
+<pad name="3" x="1.27" y="0" drill="1.016" shape="long" rot="R90"/>
+<pad name="4" x="3.81" y="0" drill="1.016" shape="long" rot="R90"/>
+<text x="-5.08" y="1.651" size="1.27" layer="25" ratio="10">&gt;NAME</text>
+<text x="-6.223" y="-0.635" size="1.27" layer="21" ratio="10">1</text>
+<text x="0.635" y="1.651" size="1.27" layer="27" ratio="10">&gt;VALUE</text>
+<text x="5.334" y="-0.635" size="1.27" layer="21" ratio="10">4</text>
+<rectangle x1="-1.524" y1="-0.254" x2="-1.016" y2="0.254" layer="51"/>
+<rectangle x1="-4.064" y1="-0.254" x2="-3.556" y2="0.254" layer="51"/>
+<rectangle x1="1.016" y1="-0.254" x2="1.524" y2="0.254" layer="51"/>
+<rectangle x1="3.556" y1="-0.254" x2="4.064" y2="0.254" layer="51"/>
+</package>
+</packages>
+</library>
+<library name="SparkFun-Resistors" urn="urn:adsk.eagle:library:532">
+<description>&lt;h3&gt;SparkFun Resistors&lt;/h3&gt;
+This library contains resistors. Reference designator:R. 
+&lt;br&gt;
+&lt;br&gt;
+We've spent an enormous amount of time creating and checking these footprints and parts, but it is &lt;b&gt; the end user's responsibility&lt;/b&gt; to ensure correctness and suitablity for a given componet or application. 
+&lt;br&gt;
+&lt;br&gt;If you enjoy using this library, please buy one of our products at &lt;a href=" www.sparkfun.com"&gt;SparkFun.com&lt;/a&gt;.
+&lt;br&gt;
+&lt;br&gt;
+&lt;b&gt;Licensing:&lt;/b&gt; Creative Commons ShareAlike 4.0 International - https://creativecommons.org/licenses/by-sa/4.0/ 
+&lt;br&gt;
+&lt;br&gt;
+You are welcome to use this library for commercial purposes. For attribution, we ask that when you begin to sell your device using our footprint, you email us with a link to the product being sold. We want bragging rights that we helped (in a very small part) to create your 8th world wonder. We would like the opportunity to feature your device on our homepage.</description>
+<packages>
+<package name="AXIAL-0.3" urn="urn:adsk.eagle:footprint:39622/1" library_version="1">
+<description>&lt;h3&gt;AXIAL-0.3&lt;/h3&gt;
+&lt;p&gt;Commonly used for 1/4W through-hole resistors. 0.3" pitch between holes.&lt;/p&gt;</description>
+<wire x1="-2.54" y1="0.762" x2="2.54" y2="0.762" width="0.2032" layer="21"/>
+<wire x1="2.54" y1="0.762" x2="2.54" y2="0" width="0.2032" layer="21"/>
+<wire x1="2.54" y1="0" x2="2.54" y2="-0.762" width="0.2032" layer="21"/>
+<wire x1="2.54" y1="-0.762" x2="-2.54" y2="-0.762" width="0.2032" layer="21"/>
+<wire x1="-2.54" y1="-0.762" x2="-2.54" y2="0" width="0.2032" layer="21"/>
+<wire x1="-2.54" y1="0" x2="-2.54" y2="0.762" width="0.2032" layer="21"/>
+<wire x1="2.54" y1="0" x2="2.794" y2="0" width="0.2032" layer="21"/>
+<wire x1="-2.54" y1="0" x2="-2.794" y2="0" width="0.2032" layer="21"/>
+<pad name="P$1" x="-3.81" y="0" drill="0.9" diameter="1.8796"/>
+<pad name="P$2" x="3.81" y="0" drill="0.9" diameter="1.8796"/>
+<text x="0" y="1.016" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;Name</text>
+<text x="0" y="-1.016" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;Value</text>
+</package>
+</packages>
+<packages3d>
+<package3d name="AXIAL-0.3" urn="urn:adsk.eagle:package:39658/1" type="box" library_version="1">
+<description>AXIAL-0.3
+Commonly used for 1/4W through-hole resistors. 0.3" pitch between holes.</description>
+<packageinstances>
+<packageinstance name="AXIAL-0.3"/>
+</packageinstances>
+</package3d>
+</packages3d>
+</library>
+<library name="capacitor-wima" urn="urn:adsk.eagle:library:116">
+<description>&lt;b&gt;WIMA Capacitors&lt;/b&gt;&lt;p&gt;
+&lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
+<packages>
+<package name="C5B3" urn="urn:adsk.eagle:footprint:5380/1" library_version="1">
+<description>&lt;B&gt;MKS2&lt;/B&gt;, 7.5 x 3 mm, grid 5.08 mm</description>
+<wire x1="-0.3048" y1="0.635" x2="-0.3048" y2="0" width="0.3048" layer="21"/>
+<wire x1="-0.3048" y1="0" x2="-0.3048" y2="-0.635" width="0.3048" layer="21"/>
+<wire x1="-0.3048" y1="0" x2="-1.524" y2="0" width="0.1524" layer="21"/>
+<wire x1="0.3302" y1="0.635" x2="0.3302" y2="0" width="0.3048" layer="21"/>
+<wire x1="0.3302" y1="0" x2="0.3302" y2="-0.635" width="0.3048" layer="21"/>
+<wire x1="0.3302" y1="0" x2="1.524" y2="0" width="0.1524" layer="21"/>
+<wire x1="-3.683" y1="1.27" x2="-3.683" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="-3.429" y1="-1.524" x2="3.429" y2="-1.524" width="0.1524" layer="21"/>
+<wire x1="3.683" y1="-1.27" x2="3.683" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="3.429" y1="1.524" x2="-3.429" y2="1.524" width="0.1524" layer="21"/>
+<wire x1="3.429" y1="1.524" x2="3.683" y2="1.27" width="0.1524" layer="21" curve="-90"/>
+<wire x1="3.429" y1="-1.524" x2="3.683" y2="-1.27" width="0.1524" layer="21" curve="90"/>
+<wire x1="-3.683" y1="-1.27" x2="-3.429" y2="-1.524" width="0.1524" layer="21" curve="90"/>
+<wire x1="-3.683" y1="1.27" x2="-3.429" y2="1.524" width="0.1524" layer="21" curve="-90"/>
+<pad name="1" x="-2.54" y="0" drill="0.8128" diameter="1.6002" shape="octagon"/>
+<pad name="2" x="2.54" y="0" drill="0.8128" diameter="1.6002" shape="octagon"/>
+<text x="-2.54" y="1.778" size="1.27" layer="25" ratio="10">&gt;NAME</text>
+<text x="-2.54" y="-3.048" size="1.27" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+</packages>
+<packages3d>
+<package3d name="C5B3" urn="urn:adsk.eagle:package:5433/1" type="box" library_version="1">
+<description>MKS2, 7.5 x 3 mm, grid 5.08 mm</description>
+<packageinstances>
+<packageinstance name="C5B3"/>
+</packageinstances>
+</package3d>
+</packages3d>
+</library>
+<library name="transistor-fet">
+<description>&lt;b&gt;Field Effect Transistors&lt;/b&gt;&lt;p&gt;
+&lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;&lt;p&gt;
+&lt;p&gt;
+Symbols changed according to IEC617&lt;p&gt; 
+All types, packages and assignment to symbols and pins checked&lt;p&gt;
+Package outlines partly checked&lt;p&gt;
+&lt;p&gt;
+JFET = junction FET&lt;p&gt;
+IGBT-x = insulated gate bipolar transistor&lt;p&gt;
+x=N: NPN; x=P: PNP&lt;p&gt;
+IGFET-mc-nnn; (IGFET=insulated gate field effect transistor)&lt;P&gt;
+m=D: depletion mode (Verdr&amp;auml;ngungstyp)&lt;p&gt;
+m=E: enhancement mode (Anreicherungstyp)&lt;p&gt;
+c: N=N-channel; P=P-Channel&lt;p&gt;
+nnn=GDS:  gate, drain, source&lt;p&gt;
+2GDS: 2 x gate, drain, source&lt;p&gt;
+GnDS: gate, n x drain, source&lt;p&gt;
+GDSB: gate, drain, source, bulk&lt;p&gt;
+&lt;p&gt;
+by R. Vogg  15.March.2002</description>
+<packages>
+<package name="TO-92">
+<description>&lt;b&gt;&lt;/b&gt;</description>
+<wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
+<wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
+<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
+<wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
+<pad name="3" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="2" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="1" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+</packages>
+</library>
+</libraries>
+<attributes>
+</attributes>
+<variantdefs>
+</variantdefs>
+<classes>
+<class number="0" name="default" width="0.3048" drill="0">
+<clearance class="0" value="0.3048"/>
+</class>
+<class number="1" name="5v" width="0.4064" drill="0">
+<clearance class="1" value="0.4064"/>
+</class>
+<class number="2" name="3v" width="0.4064" drill="0">
+<clearance class="2" value="0.4064"/>
+</class>
+<class number="3" name="Gnd" width="0.4064" drill="0">
+<clearance class="3" value="0.4064"/>
+</class>
+</classes>
+<designrules name="PCBs_io *">
+<description language="de">&lt;b&gt;MakerWorks Design Rules&lt;/b&gt;
+&lt;p&gt;
+Die Standard-Design-Rules sind so gewählt, dass sie für 
+die meisten Anwendungen passen. Sollte ihre Platine 
+besondere Anforderungen haben, treffen Sie die erforderlichen
+Einstellungen hier und speichern die Design Rules unter 
+einem neuen Namen ab.</description>
+<description language="en">&lt;b&gt;MakerWorks Design Rules&lt;/b&gt;
+&lt;p&gt;
+Please ensure your boards meet these minimum design rule requirements.</description>
+<param name="layerSetup" value="(1*16)"/>
+<param name="mtCopper" value="0.0356mm 0.0356mm 0.0356mm 0.0356mm 0.0356mm 0.0356mm 0.0356mm 0.0356mm 0.0356mm 0.0356mm 0.0356mm 0.0356mm 0.0356mm 0.0356mm 0.0356mm 0.0356mm"/>
+<param name="mtIsolate" value="1.5011mm 0.1499mm 0.2007mm 0.1499mm 0.2007mm 0.1499mm 0.2007mm 0.1499mm 0.2007mm 0.1499mm 0.2007mm 0.1499mm 0.2007mm 0.1499mm 0.2007mm"/>
+<param name="mdWireWire" value="8mil"/>
+<param name="mdWirePad" value="8mil"/>
+<param name="mdWireVia" value="8mil"/>
+<param name="mdPadPad" value="8mil"/>
+<param name="mdPadVia" value="8mil"/>
+<param name="mdViaVia" value="8mil"/>
+<param name="mdSmdPad" value="8mil"/>
+<param name="mdSmdVia" value="8mil"/>
+<param name="mdSmdSmd" value="8mil"/>
+<param name="mdViaViaSameLayer" value="8mil"/>
+<param name="mnLayersViaInSmd" value="2"/>
+<param name="mdCopperDimension" value="15mil"/>
+<param name="mdDrill" value="6mil"/>
+<param name="mdSmdStop" value="0mil"/>
+<param name="msWidth" value="6mil"/>
+<param name="msDrill" value="13mil"/>
+<param name="msMicroVia" value="13mil"/>
+<param name="msBlindViaRatio" value="0.5"/>
+<param name="rvPadTop" value="0.25"/>
+<param name="rvPadInner" value="0.25"/>
+<param name="rvPadBottom" value="0.25"/>
+<param name="rvViaOuter" value="0.25"/>
+<param name="rvViaInner" value="0.25"/>
+<param name="rvMicroViaOuter" value="0.25"/>
+<param name="rvMicroViaInner" value="0.25"/>
+<param name="rlMinPadTop" value="7mil"/>
+<param name="rlMaxPadTop" value="20mil"/>
+<param name="rlMinPadInner" value="7mil"/>
+<param name="rlMaxPadInner" value="20mil"/>
+<param name="rlMinPadBottom" value="7mil"/>
+<param name="rlMaxPadBottom" value="20mil"/>
+<param name="rlMinViaOuter" value="7mil"/>
+<param name="rlMaxViaOuter" value="20mil"/>
+<param name="rlMinViaInner" value="7mil"/>
+<param name="rlMaxViaInner" value="20mil"/>
+<param name="rlMinMicroViaOuter" value="4mil"/>
+<param name="rlMaxMicroViaOuter" value="20mil"/>
+<param name="rlMinMicroViaInner" value="4mil"/>
+<param name="rlMaxMicroViaInner" value="20mil"/>
+<param name="psTop" value="-1"/>
+<param name="psBottom" value="-1"/>
+<param name="psFirst" value="-1"/>
+<param name="psElongationLong" value="100"/>
+<param name="psElongationOffset" value="100"/>
+<param name="mvStopFrame" value="1"/>
+<param name="mvCreamFrame" value="0"/>
+<param name="mlMinStopFrame" value="3mil"/>
+<param name="mlMaxStopFrame" value="3mil"/>
+<param name="mlMinCreamFrame" value="0mil"/>
+<param name="mlMaxCreamFrame" value="0mil"/>
+<param name="mlViaStopLimit" value="0mil"/>
+<param name="srRoundness" value="0"/>
+<param name="srMinRoundness" value="0mil"/>
+<param name="srMaxRoundness" value="0mil"/>
+<param name="slThermalIsolate" value="10mil"/>
+<param name="slThermalsForVias" value="0"/>
+<param name="dpMaxLengthDifference" value="10mm"/>
+<param name="dpGapFactor" value="2.5"/>
+<param name="checkAngle" value="0"/>
+<param name="checkFont" value="1"/>
+<param name="checkRestrict" value="1"/>
+<param name="checkStop" value="0"/>
+<param name="checkValues" value="0"/>
+<param name="checkNames" value="1"/>
+<param name="checkWireStubs" value="1"/>
+<param name="checkPolygonWidth" value="0"/>
+<param name="useDiameter" value="13"/>
+<param name="maxErrors" value="50"/>
+</designrules>
+<autorouter>
+<pass name="Default">
+<param name="RoutingGrid" value="50mil"/>
+<param name="AutoGrid" value="1"/>
+<param name="Efforts" value="2"/>
+<param name="TopRouterVariant" value="1"/>
+<param name="tpViaShape" value="round"/>
+<param name="PrefDir.1" value="a"/>
+<param name="PrefDir.2" value="0"/>
+<param name="PrefDir.3" value="0"/>
+<param name="PrefDir.4" value="0"/>
+<param name="PrefDir.5" value="0"/>
+<param name="PrefDir.6" value="0"/>
+<param name="PrefDir.7" value="0"/>
+<param name="PrefDir.8" value="0"/>
+<param name="PrefDir.9" value="0"/>
+<param name="PrefDir.10" value="0"/>
+<param name="PrefDir.11" value="0"/>
+<param name="PrefDir.12" value="0"/>
+<param name="PrefDir.13" value="0"/>
+<param name="PrefDir.14" value="0"/>
+<param name="PrefDir.15" value="0"/>
+<param name="PrefDir.16" value="a"/>
+<param name="cfVia" value="8"/>
+<param name="cfNonPref" value="5"/>
+<param name="cfChangeDir" value="2"/>
+<param name="cfOrthStep" value="2"/>
+<param name="cfDiagStep" value="3"/>
+<param name="cfExtdStep" value="0"/>
+<param name="cfBonusStep" value="1"/>
+<param name="cfMalusStep" value="1"/>
+<param name="cfPadImpact" value="4"/>
+<param name="cfSmdImpact" value="4"/>
+<param name="cfBusImpact" value="0"/>
+<param name="cfHugging" value="3"/>
+<param name="cfAvoid" value="4"/>
+<param name="cfPolygon" value="10"/>
+<param name="cfBase.1" value="0"/>
+<param name="cfBase.2" value="1"/>
+<param name="cfBase.3" value="1"/>
+<param name="cfBase.4" value="1"/>
+<param name="cfBase.5" value="1"/>
+<param name="cfBase.6" value="1"/>
+<param name="cfBase.7" value="1"/>
+<param name="cfBase.8" value="1"/>
+<param name="cfBase.9" value="1"/>
+<param name="cfBase.10" value="1"/>
+<param name="cfBase.11" value="1"/>
+<param name="cfBase.12" value="1"/>
+<param name="cfBase.13" value="1"/>
+<param name="cfBase.14" value="1"/>
+<param name="cfBase.15" value="1"/>
+<param name="cfBase.16" value="0"/>
+<param name="mnVias" value="20"/>
+<param name="mnSegments" value="9999"/>
+<param name="mnExtdSteps" value="9999"/>
+<param name="mnRipupLevel" value="10"/>
+<param name="mnRipupSteps" value="100"/>
+<param name="mnRipupTotal" value="100"/>
+</pass>
+<pass name="Follow-me" refer="Default" active="yes">
+</pass>
+<pass name="Busses" refer="Default" active="yes">
+<param name="cfNonPref" value="4"/>
+<param name="cfBusImpact" value="4"/>
+<param name="cfHugging" value="0"/>
+<param name="mnVias" value="0"/>
+</pass>
+<pass name="Route" refer="Default" active="yes">
+</pass>
+<pass name="Optimize1" refer="Default" active="yes">
+<param name="cfVia" value="99"/>
+<param name="cfExtdStep" value="10"/>
+<param name="cfHugging" value="1"/>
+<param name="mnExtdSteps" value="1"/>
+<param name="mnRipupLevel" value="0"/>
+</pass>
+<pass name="Optimize2" refer="Optimize1" active="yes">
+<param name="cfNonPref" value="0"/>
+<param name="cfChangeDir" value="6"/>
+<param name="cfExtdStep" value="0"/>
+<param name="cfBonusStep" value="2"/>
+<param name="cfMalusStep" value="2"/>
+<param name="cfPadImpact" value="2"/>
+<param name="cfSmdImpact" value="2"/>
+<param name="cfHugging" value="0"/>
+</pass>
+<pass name="Optimize3" refer="Optimize2" active="yes">
+<param name="cfChangeDir" value="8"/>
+<param name="cfPadImpact" value="0"/>
+<param name="cfSmdImpact" value="0"/>
+</pass>
+<pass name="Optimize4" refer="Optimize3" active="yes">
+<param name="cfChangeDir" value="25"/>
+</pass>
+</autorouter>
+<elements>
+<element name="U$1" library="1455413453956-wemos" package="WEMOS" value="WEMOS" x="58.42" y="38.1" smashed="yes"/>
+<element name="X" library="con-wago-500" package="W237-102" value="PWR" x="76.2" y="70.485" smashed="yes" rot="R180">
+<attribute name="MF" value="" x="76.2" y="70.485" size="0.8128" layer="27" rot="R180" display="off"/>
+<attribute name="MPN" value="237-102" x="76.2" y="70.485" size="0.8128" layer="27" rot="R180" display="off"/>
+<attribute name="NAME" x="80.0462" y="75.4888" size="0.8128" layer="25" ratio="1" rot="R180"/>
+<attribute name="OC_FARNELL" value="unknown" x="76.2" y="70.485" size="0.8128" layer="27" rot="R180" display="off"/>
+<attribute name="OC_NEWARK" value="70K9898" x="76.2" y="70.485" size="0.8128" layer="27" rot="R180" display="off"/>
+<attribute name="VALUE" x="77.54" y="66.405" size="0.8128" layer="27" ratio="1" rot="R180"/>
+</element>
+<element name="J1" library="con-tycoelectronics" package="RJ45-NO-SHIELD-NOLINE" value="RJ45-8X" x="48.26" y="34.925" smashed="yes">
+<attribute name="MF" value="" x="48.26" y="34.925" size="1.778" layer="27" display="off"/>
+<attribute name="MPN" value="RJ45-8X" x="48.26" y="34.925" size="1.778" layer="27" display="off"/>
+<attribute name="NAME" x="47.735" y="36.79" size="0.8128" layer="25" ratio="1"/>
+<attribute name="OC_FARNELL" value="unknown" x="48.26" y="34.925" size="1.778" layer="27" display="off"/>
+<attribute name="OC_NEWARK" value="16R6101" x="48.26" y="34.925" size="1.778" layer="27" display="off"/>
+<attribute name="VALUE" x="45.945" y="38.665" size="0.8128" layer="27" ratio="1"/>
+</element>
+<element name="R1" library="SparkFun-Resistors" library_urn="urn:adsk.eagle:library:532" package="AXIAL-0.3" package3d_urn="urn:adsk.eagle:package:39658/1" value="10k" x="64.897" y="41.9862" smashed="yes" rot="R90">
+<attribute name="NAME" x="66.781" y="42.2862" size="0.8128" layer="25" font="vector" ratio="1" rot="R180" align="bottom-center"/>
+<attribute name="PROD_ID" value="RES-12183" x="64.897" y="41.9862" size="1.778" layer="27" rot="R90" display="off"/>
+</element>
+<element name="U$2" library="holes" package="3,0" value="" x="45.72" y="69.85" smashed="yes"/>
+<element name="U$4" library="holes" package="3,0" value="" x="71.12" y="34.29" smashed="yes"/>
+<element name="JP1" library="pinhead" package="1X02" value="BZR" x="57.785" y="69.85" smashed="yes" rot="R90">
+<attribute name="VALUE" x="58.96" y="66.71" size="0.8128" layer="27" ratio="1" rot="R180"/>
+</element>
+<element name="SV1" library="con-lstb" package="MA04-1" value="RELAY" x="48.26" y="51.435" smashed="yes">
+<attribute name="MF" value="" x="48.26" y="51.435" size="1.778" layer="27" display="off"/>
+<attribute name="MPN" value="" x="48.26" y="51.435" size="1.778" layer="27" display="off"/>
+<attribute name="OC_FARNELL" value="unknown" x="48.26" y="51.435" size="1.778" layer="27" display="off"/>
+<attribute name="OC_NEWARK" value="unknown" x="48.26" y="51.435" size="1.778" layer="27" display="off"/>
+<attribute name="VALUE" x="46.495" y="53.386" size="0.8128" layer="27" ratio="1"/>
+</element>
+<element name="SV2" library="con-lstb" package="MA04-1" value="LCD" x="48.26" y="60.325" smashed="yes">
+<attribute name="MF" value="" x="48.26" y="60.325" size="1.778" layer="27" display="off"/>
+<attribute name="MPN" value="" x="48.26" y="60.325" size="1.778" layer="27" display="off"/>
+<attribute name="OC_FARNELL" value="unknown" x="48.26" y="60.325" size="1.778" layer="27" display="off"/>
+<attribute name="OC_NEWARK" value="unknown" x="48.26" y="60.325" size="1.778" layer="27" display="off"/>
+<attribute name="VALUE" x="47.295" y="62.376" size="0.8128" layer="27" ratio="1"/>
+</element>
+<element name="R2" library="SparkFun-Resistors" library_urn="urn:adsk.eagle:library:532" package="AXIAL-0.3" package3d_urn="urn:adsk.eagle:package:39658/1" value="10k" x="71.24065" y="48.13549375" smashed="yes" rot="R180">
+<attribute name="NAME" x="71.34065" y="49.91949375" size="0.8128" layer="25" font="vector" ratio="1" rot="R180" align="bottom-center"/>
+<attribute name="PROD_ID" value="RES-12183" x="71.24065" y="48.13549375" size="1.778" layer="27" rot="R180" display="off"/>
+</element>
+<element name="R3" library="SparkFun-Resistors" library_urn="urn:adsk.eagle:library:532" package="AXIAL-0.3" package3d_urn="urn:adsk.eagle:package:39658/1" value="10k" x="61.29065" y="59.6294875" smashed="yes">
+<attribute name="NAME" x="61.29065" y="57.6454875" size="0.8128" layer="25" font="vector" ratio="1" align="bottom-center"/>
+<attribute name="PROD_ID" value="RES-12183" x="61.29065" y="59.6294875" size="1.778" layer="27" display="off"/>
+</element>
+<element name="R4" library="SparkFun-Resistors" library_urn="urn:adsk.eagle:library:532" package="AXIAL-0.3" package3d_urn="urn:adsk.eagle:package:39658/1" value="10k" x="71.24065" y="45.282996875" smashed="yes">
+<attribute name="NAME" x="71.24065" y="46.298996875" size="0.8128" layer="25" font="vector" ratio="1" align="bottom-center"/>
+<attribute name="PROD_ID" value="RES-12183" x="71.24065" y="45.282996875" size="1.778" layer="27" display="off"/>
+</element>
+<element name="R5" library="SparkFun-Resistors" library_urn="urn:adsk.eagle:library:532" package="AXIAL-0.3" package3d_urn="urn:adsk.eagle:package:39658/1" value="10k" x="61.29065" y="62.181984375" smashed="yes">
+<attribute name="NAME" x="61.29065" y="63.397984375" size="0.8128" layer="25" font="vector" ratio="1" align="bottom-center"/>
+<attribute name="PROD_ID" value="RES-12183" x="61.29065" y="62.181984375" size="1.778" layer="27" display="off"/>
+</element>
+<element name="C1" library="capacitor-wima" library_urn="urn:adsk.eagle:library:116" package="C5B3" package3d_urn="urn:adsk.eagle:package:5433/1" value="100uF" x="66.04" y="69.85" smashed="yes" rot="R270">
+<attribute name="NAME" x="62.918" y="72.39" size="0.8128" layer="25" ratio="1"/>
+</element>
+<element name="Q1" library="transistor-fet" package="TO-92" value="2N7000" x="71.249365625" y="52.791390625" smashed="yes" rot="R180">
+<attribute name="NAME" x="72.074365625" y="55.756390625" size="0.8128" layer="25" ratio="1" rot="R180"/>
+</element>
+<element name="Q2" library="transistor-fet" package="TO-92" value="2N7000" x="71.249365625" y="41.7449" smashed="yes" rot="R180">
+<attribute name="NAME" x="72.074365625" y="44.3099" size="0.8128" layer="25" ratio="1" rot="R180"/>
+</element>
+</elements>
+<signals>
+<signal name="GND" class="3">
+<contactref element="U$1" pad="GND"/>
+<contactref element="X" pad="2"/>
+<contactref element="JP1" pad="2"/>
+<contactref element="SV1" pad="1"/>
+<contactref element="SV2" pad="1"/>
+<contactref element="C1" pad="1"/>
+<contactref element="J1" pad="5"/>
+<wire x1="81.28" y1="40.64" x2="78.3954" y2="43.5246" width="0.8" layer="16"/>
+<wire x1="78.3954" y1="67.0596" x2="73.7" y2="71.755" width="0.8" layer="16"/>
+<wire x1="44.45" y1="60.325" x2="44.45" y2="51.435" width="0.8" layer="1"/>
+<wire x1="44.45" y1="60.325" x2="44.45" y2="61.9452625" width="0.8" layer="1"/>
+<wire x1="53.6247375" y1="71.12" x2="57.785" y2="71.12" width="0.8" layer="1"/>
+<wire x1="44.45" y1="61.9452625" x2="53.6247375" y2="71.12" width="0.8" layer="1"/>
+<wire x1="57.785" y1="71.12" x2="64.77" y2="71.12" width="0.8" layer="1"/>
+<wire x1="64.77" y1="71.12" x2="66.04" y2="72.39" width="0.8" layer="1"/>
+<wire x1="66.04" y1="72.39" x2="73.065" y2="72.39" width="0.8" layer="1"/>
+<wire x1="73.065" y1="72.39" x2="73.7" y2="71.755" width="0.8" layer="1"/>
+<wire x1="48.895" y1="41.275" x2="47.0154" y2="39.3954" width="0.8" layer="16"/>
+<wire x1="43.3991" y1="39.3954" x2="41.4655" y2="41.329" width="0.8" layer="16"/>
+<wire x1="41.4655" y1="41.329" x2="41.4655" y2="48.3997" width="0.8" layer="16"/>
+<wire x1="44.45" y1="51.3842" x2="44.45" y2="51.435" width="0.8" layer="16"/>
+<wire x1="47.0154" y1="39.3954" x2="43.3991" y2="39.3954" width="0.8" layer="16"/>
+<wire x1="41.4655" y1="48.3997" x2="44.45" y2="51.3842" width="0.8" layer="16"/>
+<wire x1="78.3954" y1="43.5246" x2="78.3954" y2="67.0596" width="0.8" layer="16"/>
+</signal>
+<signal name="5V" class="1">
+<contactref element="U$1" pad="5V"/>
+<contactref element="X" pad="1"/>
+<contactref element="SV1" pad="4"/>
+<contactref element="SV2" pad="2"/>
+<contactref element="C1" pad="2"/>
+<contactref element="R3" pad="P$1"/>
+<contactref element="R5" pad="P$1"/>
+<wire x1="66.04" y1="67.31" x2="60.911984375" y2="62.181984375" width="0.8" layer="16"/>
+<wire x1="60.911984375" y1="62.181984375" x2="57.48065" y2="62.181984375" width="0.8" layer="16"/>
+<wire x1="66.04" y1="67.31" x2="74.255" y2="67.31" width="0.8" layer="1"/>
+<wire x1="74.255" y1="67.31" x2="78.7" y2="71.755" width="0.8" layer="1"/>
+<wire x1="81.28" y1="38.1" x2="82.7058" y2="39.5258" width="0.8" layer="1"/>
+<wire x1="82.7058" y1="67.7492" x2="78.7" y2="71.755" width="0.8" layer="1"/>
+<wire x1="82.7058" y1="39.5258" x2="82.7058" y2="67.7492" width="0.8" layer="1"/>
+<wire x1="57.48065" y1="62.181984375" x2="57.48065" y2="59.6294875" width="0.8" layer="1"/>
+<wire x1="46.99" y1="60.325" x2="46.99" y2="57.8866" width="0.8" layer="1"/>
+<wire x1="49.276" y1="55.6006" x2="49.3522" y2="55.6006" width="0.8" layer="1"/>
+<wire x1="49.3522" y1="55.6006" x2="52.07" y2="52.8828" width="0.8" layer="1"/>
+<wire x1="52.07" y1="52.8828" x2="52.07" y2="51.435" width="0.8" layer="1"/>
+<wire x1="46.99" y1="57.8866" x2="49.276" y2="55.6006" width="0.8" layer="1"/>
+<wire x1="52.07" y1="51.435" x2="52.07" y2="52.4129" width="0.8" layer="16"/>
+<wire x1="57.48065" y1="59.6294875" x2="57.48065" y2="57.82355" width="0.8" layer="16"/>
+<wire x1="57.48065" y1="57.82355" x2="52.07" y2="52.4129" width="0.8" layer="16"/>
+</signal>
+<signal name="3V3" class="2">
+<contactref element="U$1" pad="3V3"/>
+<contactref element="R1" pad="P$1"/>
+<contactref element="J1" pad="3"/>
+<contactref element="R2" pad="P$1"/>
+<contactref element="R4" pad="P$1"/>
+<contactref element="Q1" pad="2"/>
+<contactref element="Q2" pad="2"/>
+<wire x1="71.249365625" y1="50.886390625" x2="71.249365625" y2="49.1017125" width="0.8" layer="1"/>
+<wire x1="75.05065" y1="48.13549375" x2="74.0002625" y2="48.13549375" width="0.8" layer="1"/>
+<wire x1="74.0002625" y1="48.13549375" x2="71.249365625" y2="50.886390625" width="0.8" layer="1"/>
+<wire x1="64.897" y1="38.1762" x2="58.4962" y2="38.1762" width="0.8" layer="1"/>
+<wire x1="58.4962" y1="38.1762" x2="58.42" y2="38.1" width="0.8" layer="1"/>
+<wire x1="64.897" y1="38.1762" x2="66.9925" y2="40.2717" width="0.8" layer="1"/>
+<wire x1="66.9925" y1="40.2717" x2="66.9925" y2="44.844846875" width="0.8" layer="1"/>
+<wire x1="58.42" y1="38.1" x2="49.53" y2="38.1" width="0.8" layer="1"/>
+<wire x1="49.53" y1="38.1" x2="46.355" y2="41.275" width="0.8" layer="1"/>
+<wire x1="71.249365625" y1="49.1017125" x2="70.523828125" y2="48.376175" width="0.8" layer="1"/>
+<wire x1="70.523828125" y1="48.376175" x2="67.43065" y2="45.282996875" width="0.8" layer="1"/>
+<wire x1="66.9925" y1="44.844846875" x2="67.43065" y2="45.282996875" width="0.8" layer="1"/>
+<wire x1="71.249365625" y1="39.8399" x2="68.9102" y2="39.8399" width="0.8" layer="16"/>
+<wire x1="67.2465" y1="38.1762" x2="64.897" y2="38.1762" width="0.8" layer="16"/>
+<wire x1="68.9102" y1="39.8399" x2="67.2465" y2="38.1762" width="0.8" layer="16"/>
+</signal>
+<signal name="D6">
+<contactref element="R1" pad="P$2"/>
+<contactref element="U$1" pad="D6"/>
+<contactref element="J1" pad="4"/>
+<wire x1="58.42" y1="45.72" x2="64.8208" y2="45.72" width="0.8" layer="1"/>
+<wire x1="64.8208" y1="45.72" x2="64.897" y2="45.7962" width="0.8" layer="1"/>
+<wire x1="47.625" y1="43.815" x2="50.53" y2="46.72" width="0.8" layer="1"/>
+<wire x1="57.42" y1="46.72" x2="50.53" y2="46.72" width="0.8" layer="1"/>
+<wire x1="57.42" y1="46.72" x2="58.42" y2="45.72" width="0.8" layer="1"/>
+</signal>
+<signal name="D7">
+<contactref element="U$1" pad="D7"/>
+<contactref element="J1" pad="6"/>
+<wire x1="53.8889" y1="45.315" x2="51.665" y2="45.315" width="0.8" layer="1"/>
+<wire x1="50.165" y1="43.815" x2="51.665" y2="45.315" width="0.8" layer="1"/>
+<wire x1="58.4194" y1="43.1794" x2="58.42" y2="43.18" width="0.8" layer="1"/>
+<wire x1="53.8889" y1="45.315" x2="56.0245" y2="43.1794" width="0.8" layer="1"/>
+<wire x1="56.0245" y1="43.1794" x2="58.4194" y2="43.1794" width="0.8" layer="1"/>
+</signal>
+<signal name="N$6">
+<contactref element="U$1" pad="D3"/>
+<contactref element="JP1" pad="1"/>
+<wire x1="58.3946" y1="69.1896" x2="68.8467" y2="69.1896" width="0.8" layer="16"/>
+<wire x1="58.3946" y1="69.1896" x2="57.785" y2="68.58" width="0.8" layer="16"/>
+<wire x1="73.7363" y1="64.3" x2="73.8" y2="64.3" width="0.8" layer="16"/>
+<via x="73.8" y="64.3" extent="1-16" drill="0.35"/>
+<wire x1="73.8" y1="64.3" x2="79.8" y2="58.3" width="0.8" layer="1"/>
+<wire x1="79.8" y1="58.3" x2="79.8" y2="58.2" width="0.8" layer="1"/>
+<via x="79.8" y="58.2" extent="1-16" drill="0.35"/>
+<wire x1="68.8467" y1="69.1896" x2="73.7363" y2="64.3" width="0.8" layer="16"/>
+<wire x1="81.28" y1="45.72" x2="79.8" y2="47.2" width="0.8" layer="16"/>
+<wire x1="79.8" y1="47.2" x2="79.8" y2="58.2" width="0.8" layer="16"/>
+</signal>
+<signal name="N$7">
+<contactref element="SV1" pad="2"/>
+<contactref element="U$1" pad="D5"/>
+<wire x1="46.99" y1="51.435" x2="46.99" y2="49.3268" width="0.8" layer="1"/>
+<wire x1="46.99" y1="49.3268" x2="48.333" y2="47.9838" width="0.8" layer="1"/>
+<wire x1="58.42" y1="48.26" x2="58.1438" y2="47.9838" width="0.8" layer="1"/>
+<wire x1="58.1438" y1="47.9838" x2="48.333" y2="47.9838" width="0.8" layer="1"/>
+</signal>
+<signal name="N$8">
+<contactref element="SV1" pad="3"/>
+<contactref element="U$1" pad="D0"/>
+<wire x1="49.53" y1="51.435" x2="49.6316" y2="51.3334" width="0.8" layer="1"/>
+<wire x1="49.6316" y1="51.3334" x2="49.6316" y2="49.5173" width="0.8" layer="1"/>
+<wire x1="49.6316" y1="49.5173" x2="50.0507" y2="49.0982" width="0.8" layer="1"/>
+<wire x1="50.0507" y1="49.0982" x2="56.7182" y2="49.0982" width="0.8" layer="1"/>
+<wire x1="56.7182" y1="49.0982" x2="58.42" y2="50.8" width="0.8" layer="1"/>
+</signal>
+<signal name="SCL5V">
+<contactref element="SV2" pad="4"/>
+<contactref element="R3" pad="P$2"/>
+<contactref element="Q1" pad="3"/>
+<wire x1="52.07" y1="60.325" x2="54.5401" y2="57.8549" width="0.8" layer="1"/>
+<wire x1="65.10065" y1="59.6294875" x2="65.10065" y2="57.67010625" width="0.8" layer="1"/>
+<wire x1="69.979365625" y1="52.791390625" x2="65.10065" y2="57.67010625" width="0.8" layer="1"/>
+<wire x1="54.5401" y1="57.8549" x2="60.0549" y2="57.8549" width="0.8" layer="1"/>
+<wire x1="61.8294875" y1="59.6294875" x2="65.10065" y2="59.6294875" width="0.8" layer="1"/>
+<wire x1="60.0549" y1="57.8549" x2="61.8294875" y2="59.6294875" width="0.8" layer="1"/>
+</signal>
+<signal name="5V_SDA">
+<contactref element="SV2" pad="3"/>
+<contactref element="R5" pad="P$2"/>
+<contactref element="Q2" pad="3"/>
+<wire x1="65.10065" y1="62.181984375" x2="62.233234375" y2="65.0494" width="0.8" layer="1"/>
+<wire x1="53.33634375" y1="65.0494" x2="49.53" y2="61.24305625" width="0.8" layer="1"/>
+<wire x1="49.53" y1="61.24305625" x2="49.53" y2="60.325" width="0.8" layer="1"/>
+<wire x1="62.233234375" y1="65.0494" x2="53.33634375" y2="65.0494" width="0.8" layer="1"/>
+<wire x1="69.979365625" y1="45.679365625" x2="75" y2="50.7" width="0.8" layer="16"/>
+<wire x1="75" y1="50.7" x2="75" y2="54.6" width="0.8" layer="16"/>
+<wire x1="67.418015625" y1="62.181984375" x2="65.10065" y2="62.181984375" width="0.8" layer="16"/>
+<wire x1="69.979365625" y1="41.7449" x2="69.979365625" y2="45.679365625" width="0.8" layer="16"/>
+<wire x1="75" y1="54.6" x2="67.418015625" y2="62.181984375" width="0.8" layer="16"/>
+</signal>
+<signal name="N$1">
+<contactref element="R4" pad="P$2"/>
+<contactref element="Q2" pad="1"/>
+<contactref element="U$1" pad="D2"/>
+<wire x1="72.519365625" y1="41.7449" x2="72.519365625" y2="42.7517125" width="0.8" layer="1"/>
+<wire x1="72.519365625" y1="42.7517125" x2="75.05065" y2="45.282996875" width="0.8" layer="1"/>
+<wire x1="75.05065" y1="45.282996875" x2="78.027615625" y2="48.26" width="0.8" layer="1"/>
+<wire x1="78.027615625" y1="48.26" x2="81.28" y2="48.26" width="0.8" layer="1"/>
+</signal>
+<signal name="N$5">
+<contactref element="R2" pad="P$2"/>
+<contactref element="Q1" pad="1"/>
+<contactref element="U$1" pad="D1"/>
+<wire x1="81.28" y1="50.8" x2="79.288609375" y2="52.791390625" width="0.8" layer="1"/>
+<wire x1="79.288609375" y1="52.791390625" x2="72.519365625" y2="52.791390625" width="0.8" layer="1"/>
+<wire x1="67.43065" y1="48.13549375" x2="67.43065" y2="53.34635" width="0.8" layer="16"/>
+<wire x1="70.56105625" y1="54.7497" x2="72.519365625" y2="52.791390625" width="0.8" layer="16"/>
+<wire x1="67.43065" y1="53.34635" x2="68.834" y2="54.7497" width="0.8" layer="16"/>
+<wire x1="68.834" y1="54.7497" x2="70.56105625" y2="54.7497" width="0.8" layer="16"/>
+</signal>
+</signals>
+<mfgpreviewcolors>
+<mfgpreviewcolor name="soldermaskcolor" color="0xC8008000"/>
+<mfgpreviewcolor name="silkscreencolor" color="0xFFFEFEFE"/>
+<mfgpreviewcolor name="backgroundcolor" color="0xFF282828"/>
+<mfgpreviewcolor name="coppercolor" color="0xFFFFBF00"/>
+<mfgpreviewcolor name="substratecolor" color="0xFF786E46"/>
+</mfgpreviewcolors>
+</board>
+</drawing>
+<compatibility>
+<note version="6.3" minversion="6.2.2" severity="warning">
+Since Version 6.2.2 text objects can contain more than one line,
+which will not be processed correctly with this version.
+</note>
+<note version="8.2" severity="warning">
+Since Version 8.2, EAGLE supports online libraries. The ids
+of those online libraries will not be understood (or retained)
+with this version.
+</note>
+<note version="8.3" severity="warning">
+Since Version 8.3, EAGLE supports URNs for individual library
+assets (packages, symbols, and devices). The URNs of those assets
+will not be understood (or retained) with this version.
+</note>
+<note version="8.3" severity="warning">
+Since Version 8.3, EAGLE supports the association of 3D packages
+with devices in libraries, schematics, and board files. Those 3D
+packages will not be understood (or retained) with this version.
+</note>
+</compatibility>
+</eagle>

--- a/hardware/D1 Breakout - LCD TH Dupont RJ45 Logo.sch
+++ b/hardware/D1 Breakout - LCD TH Dupont RJ45 Logo.sch
@@ -1,0 +1,3055 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE eagle SYSTEM "eagle.dtd">
+<eagle version="9.4.2">
+<drawing>
+<settings>
+<setting alwaysvectorfont="yes"/>
+<setting keepoldvectorfont="yes"/>
+<setting verticaltext="up"/>
+</settings>
+<grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="no" altdistance="0.01" altunitdist="inch" altunit="inch"/>
+<layers>
+<layer number="1" name="Top" color="4" fill="1" visible="no" active="no"/>
+<layer number="2" name="Route2" color="1" fill="3" visible="no" active="no"/>
+<layer number="3" name="Route3" color="4" fill="3" visible="no" active="no"/>
+<layer number="4" name="Route4" color="1" fill="4" visible="no" active="no"/>
+<layer number="5" name="Route5" color="4" fill="4" visible="no" active="no"/>
+<layer number="6" name="Route6" color="1" fill="8" visible="no" active="no"/>
+<layer number="7" name="Route7" color="4" fill="8" visible="no" active="no"/>
+<layer number="8" name="Route8" color="1" fill="2" visible="no" active="no"/>
+<layer number="9" name="Route9" color="4" fill="2" visible="no" active="no"/>
+<layer number="10" name="Route10" color="1" fill="7" visible="no" active="no"/>
+<layer number="11" name="Route11" color="4" fill="7" visible="no" active="no"/>
+<layer number="12" name="Route12" color="1" fill="5" visible="no" active="no"/>
+<layer number="13" name="Route13" color="4" fill="5" visible="no" active="no"/>
+<layer number="14" name="Route14" color="1" fill="6" visible="no" active="no"/>
+<layer number="15" name="Route15" color="4" fill="6" visible="no" active="no"/>
+<layer number="16" name="Bottom" color="1" fill="1" visible="no" active="no"/>
+<layer number="17" name="Pads" color="2" fill="1" visible="no" active="no"/>
+<layer number="18" name="Vias" color="2" fill="1" visible="no" active="no"/>
+<layer number="19" name="Unrouted" color="6" fill="1" visible="no" active="no"/>
+<layer number="20" name="Dimension" color="15" fill="1" visible="no" active="no"/>
+<layer number="21" name="tPlace" color="7" fill="1" visible="no" active="no"/>
+<layer number="22" name="bPlace" color="7" fill="1" visible="no" active="no"/>
+<layer number="23" name="tOrigins" color="15" fill="1" visible="no" active="no"/>
+<layer number="24" name="bOrigins" color="15" fill="1" visible="no" active="no"/>
+<layer number="25" name="tNames" color="7" fill="1" visible="no" active="no"/>
+<layer number="26" name="bNames" color="7" fill="1" visible="no" active="no"/>
+<layer number="27" name="tValues" color="7" fill="1" visible="no" active="no"/>
+<layer number="28" name="bValues" color="7" fill="1" visible="no" active="no"/>
+<layer number="29" name="tStop" color="7" fill="3" visible="no" active="no"/>
+<layer number="30" name="bStop" color="7" fill="6" visible="no" active="no"/>
+<layer number="31" name="tCream" color="7" fill="4" visible="no" active="no"/>
+<layer number="32" name="bCream" color="7" fill="5" visible="no" active="no"/>
+<layer number="33" name="tFinish" color="6" fill="3" visible="no" active="no"/>
+<layer number="34" name="bFinish" color="6" fill="6" visible="no" active="no"/>
+<layer number="35" name="tGlue" color="7" fill="4" visible="no" active="no"/>
+<layer number="36" name="bGlue" color="7" fill="5" visible="no" active="no"/>
+<layer number="37" name="tTest" color="7" fill="1" visible="no" active="no"/>
+<layer number="38" name="bTest" color="7" fill="1" visible="no" active="no"/>
+<layer number="39" name="tKeepout" color="4" fill="11" visible="no" active="no"/>
+<layer number="40" name="bKeepout" color="1" fill="11" visible="no" active="no"/>
+<layer number="41" name="tRestrict" color="4" fill="10" visible="no" active="no"/>
+<layer number="42" name="bRestrict" color="1" fill="10" visible="no" active="no"/>
+<layer number="43" name="vRestrict" color="2" fill="10" visible="no" active="no"/>
+<layer number="44" name="Drills" color="7" fill="1" visible="no" active="no"/>
+<layer number="45" name="Holes" color="7" fill="1" visible="no" active="no"/>
+<layer number="46" name="Milling" color="3" fill="1" visible="no" active="no"/>
+<layer number="47" name="Measures" color="7" fill="1" visible="no" active="no"/>
+<layer number="48" name="Document" color="7" fill="1" visible="no" active="no"/>
+<layer number="49" name="Reference" color="7" fill="1" visible="no" active="no"/>
+<layer number="50" name="dxf" color="7" fill="1" visible="no" active="no"/>
+<layer number="51" name="tDocu" color="7" fill="1" visible="no" active="no"/>
+<layer number="52" name="bDocu" color="7" fill="1" visible="no" active="no"/>
+<layer number="53" name="tGND_GNDA" color="7" fill="9" visible="no" active="no"/>
+<layer number="54" name="bGND_GNDA" color="1" fill="9" visible="no" active="no"/>
+<layer number="56" name="wert" color="7" fill="1" visible="no" active="no"/>
+<layer number="57" name="tCAD" color="7" fill="1" visible="no" active="no"/>
+<layer number="59" name="tCarbon" color="7" fill="1" visible="no" active="no"/>
+<layer number="60" name="bCarbon" color="7" fill="1" visible="no" active="no"/>
+<layer number="90" name="Modules" color="5" fill="1" visible="yes" active="yes"/>
+<layer number="91" name="Nets" color="2" fill="1" visible="yes" active="yes"/>
+<layer number="92" name="Busses" color="1" fill="1" visible="yes" active="yes"/>
+<layer number="93" name="Pins" color="2" fill="1" visible="no" active="yes"/>
+<layer number="94" name="Symbols" color="4" fill="1" visible="yes" active="yes"/>
+<layer number="95" name="Names" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="96" name="Values" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="97" name="Info" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="98" name="Guide" color="6" fill="1" visible="yes" active="yes"/>
+<layer number="99" name="SpiceOrder" color="5" fill="1" visible="yes" active="yes"/>
+<layer number="100" name="Muster" color="7" fill="1" visible="no" active="no"/>
+<layer number="101" name="Patch_Top" color="12" fill="4" visible="yes" active="yes"/>
+<layer number="102" name="Vscore" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="103" name="tMap" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="104" name="Name" color="16" fill="1" visible="yes" active="yes"/>
+<layer number="105" name="tPlate" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="106" name="bPlate" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="107" name="Crop" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="108" name="tplace-old" color="10" fill="1" visible="yes" active="yes"/>
+<layer number="109" name="ref-old" color="11" fill="1" visible="yes" active="yes"/>
+<layer number="110" name="fp0" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="111" name="LPC17xx" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="112" name="tSilk" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="113" name="IDFDebug" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="114" name="Badge_Outline" color="11" fill="1" visible="no" active="no"/>
+<layer number="115" name="ReferenceISLANDS" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="116" name="Patch_BOT" color="9" fill="4" visible="yes" active="yes"/>
+<layer number="118" name="Rect_Pads" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="121" name="_tsilk" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="122" name="_bsilk" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="123" name="tTestmark" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="124" name="bTestmark" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="125" name="_tNames" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="126" name="_bNames" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="127" name="_tValues" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="128" name="_bValues" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="129" name="Mask" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="131" name="tAdjust" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="132" name="bAdjust" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="144" name="Drill_legend" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="150" name="Notes" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="151" name="HeatSink" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="152" name="_bDocu" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="153" name="FabDoc1" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="154" name="FabDoc2" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="155" name="FabDoc3" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="199" name="Contour" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="200" name="200bmp" color="1" fill="10" visible="yes" active="yes"/>
+<layer number="201" name="201bmp" color="2" fill="10" visible="yes" active="yes"/>
+<layer number="202" name="202bmp" color="3" fill="10" visible="yes" active="yes"/>
+<layer number="203" name="203bmp" color="4" fill="10" visible="yes" active="yes"/>
+<layer number="204" name="204bmp" color="5" fill="10" visible="yes" active="yes"/>
+<layer number="205" name="205bmp" color="6" fill="10" visible="yes" active="yes"/>
+<layer number="206" name="206bmp" color="7" fill="10" visible="yes" active="yes"/>
+<layer number="207" name="207bmp" color="8" fill="10" visible="yes" active="yes"/>
+<layer number="208" name="208bmp" color="9" fill="10" visible="yes" active="yes"/>
+<layer number="209" name="209bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="210" name="210bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="211" name="211bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="212" name="212bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="213" name="213bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="214" name="214bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="215" name="215bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="216" name="216bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="217" name="217bmp" color="18" fill="1" visible="no" active="no"/>
+<layer number="218" name="218bmp" color="19" fill="1" visible="no" active="no"/>
+<layer number="219" name="219bmp" color="20" fill="1" visible="no" active="no"/>
+<layer number="220" name="220bmp" color="21" fill="1" visible="no" active="no"/>
+<layer number="221" name="221bmp" color="22" fill="1" visible="no" active="no"/>
+<layer number="222" name="222bmp" color="23" fill="1" visible="no" active="no"/>
+<layer number="223" name="223bmp" color="24" fill="1" visible="no" active="no"/>
+<layer number="224" name="224bmp" color="25" fill="1" visible="no" active="no"/>
+<layer number="225" name="225bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="226" name="226bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="227" name="227bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="228" name="228bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="229" name="229bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="230" name="230bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="231" name="231bmp" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="248" name="Housing" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="249" name="Edge" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="250" name="Descript" color="3" fill="1" visible="no" active="no"/>
+<layer number="251" name="SMDround" color="12" fill="11" visible="no" active="no"/>
+<layer number="254" name="cooling" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="255" name="routoute" color="7" fill="1" visible="yes" active="yes"/>
+</layers>
+<schematic xreflabel="%F%N/%S.%C%R" xrefpart="/%S.%C%R">
+<libraries>
+<library name="1455413453956-wemos">
+<packages>
+<package name="WEMOS">
+<description>WEMOS Controller socket</description>
+<pad name="3V3" x="0" y="0" drill="0.8" shape="octagon"/>
+<pad name="D8" x="0" y="2.54" drill="0.8" shape="octagon"/>
+<pad name="D7" x="0" y="5.08" drill="0.8" shape="octagon"/>
+<pad name="D6" x="0" y="7.62" drill="0.8" shape="octagon"/>
+<pad name="D5" x="0" y="10.16" drill="0.8" shape="octagon"/>
+<pad name="D0" x="0" y="12.7" drill="0.8" shape="octagon"/>
+<pad name="A0" x="0" y="15.24" drill="0.8" shape="octagon"/>
+<pad name="RST" x="0" y="17.78" drill="0.8" shape="octagon"/>
+<pad name="5V" x="22.86" y="0" drill="0.8" shape="octagon"/>
+<pad name="GND" x="22.86" y="2.54" drill="0.8" shape="octagon"/>
+<pad name="D4" x="22.86" y="5.08" drill="0.8" shape="octagon"/>
+<pad name="D3" x="22.86" y="7.62" drill="0.8" shape="octagon"/>
+<pad name="D2" x="22.86" y="10.16" drill="0.8" shape="octagon"/>
+<pad name="D1" x="22.86" y="12.7" drill="0.8" shape="octagon"/>
+<pad name="RX" x="22.86" y="15.24" drill="0.8" shape="octagon"/>
+<pad name="TX" x="22.86" y="17.78" drill="0.8" shape="octagon"/>
+<rectangle x1="-1.27" y1="-1.27" x2="1.27" y2="19.05" layer="21"/>
+<rectangle x1="21.59" y1="-1.27" x2="24.13" y2="19.05" layer="21"/>
+<text x="8.89" y="19.05" size="0.8128" layer="21" font="vector"> WEMOS
+Controller</text>
+<wire x1="2" y1="-9" x2="25" y2="-9" width="0.127" layer="21"/>
+<wire x1="25" y1="-9" x2="25" y2="24" width="0.127" layer="21"/>
+<wire x1="22" y1="27" x2="1" y2="27" width="0.127" layer="21"/>
+<text x="7.635" y="23.54" size="0.8128" layer="21" font="vector">Radio Antenna
+  Facing UP</text>
+<text x="7.635" y="-7.43" size="0.8128" layer="21" font="vector">   USB bottom
+Facing DOWN/PCB</text>
+<wire x1="-2" y1="24" x2="-2" y2="-2" width="0.127" layer="21"/>
+<wire x1="-2" y1="24" x2="1" y2="27" width="0.127" layer="21" curve="-90"/>
+<wire x1="25" y1="24" x2="22" y2="27" width="0.127" layer="21" curve="90"/>
+<wire x1="2" y1="-9" x2="2" y2="-4" width="0.127" layer="21"/>
+<wire x1="2" y1="-4" x2="-2" y2="-2" width="0.127" layer="21"/>
+<text x="1.905" y="-0.635" size="1.27" layer="21" font="vector">3V3</text>
+<text x="1.905" y="1.905" size="1.27" layer="21" font="vector">D8</text>
+<text x="1.905" y="4.445" size="1.27" layer="21" font="vector">D7</text>
+<text x="1.905" y="6.985" size="1.27" layer="21" font="vector">D6</text>
+<text x="1.905" y="9.525" size="1.27" layer="21" font="vector">D5</text>
+<text x="1.905" y="12.065" size="1.27" layer="21" font="vector">D0</text>
+<text x="1.905" y="14.605" size="1.27" layer="21" font="vector">A0</text>
+<text x="1.905" y="17.145" size="1.27" layer="21" font="vector">RST</text>
+<text x="19.05" y="-0.635" size="1.27" layer="21" font="vector">5V</text>
+<text x="17.78" y="1.905" size="1.27" layer="21" font="vector">GND</text>
+<text x="19.05" y="4.445" size="1.27" layer="21" font="vector">D4</text>
+<text x="19.05" y="6.985" size="1.27" layer="21" font="vector">D3</text>
+<text x="19.05" y="9.525" size="1.27" layer="21" font="vector">D2</text>
+<text x="19.05" y="12.065" size="1.27" layer="21" font="vector">D1</text>
+<text x="19.05" y="14.605" size="1.27" layer="21" font="vector">RX</text>
+<text x="19.05" y="17.145" size="1.27" layer="21" font="vector">TX</text>
+</package>
+</packages>
+<symbols>
+<symbol name="WEMOS">
+<wire x1="0" y1="0" x2="0" y2="22.86" width="0.254" layer="94"/>
+<wire x1="0" y1="22.86" x2="15.24" y2="22.86" width="0.254" layer="94"/>
+<wire x1="15.24" y1="22.86" x2="15.24" y2="0" width="0.254" layer="94"/>
+<wire x1="15.24" y1="0" x2="0" y2="0" width="0.254" layer="94"/>
+<pin name="3V3" x="-5.08" y="2.54" length="middle"/>
+<pin name="D8" x="-5.08" y="5.08" length="middle"/>
+<pin name="D7" x="-5.08" y="7.62" length="middle"/>
+<pin name="D6" x="-5.08" y="10.16" length="middle"/>
+<pin name="D5" x="-5.08" y="12.7" length="middle"/>
+<pin name="D0" x="-5.08" y="15.24" length="middle"/>
+<pin name="A0" x="-5.08" y="17.78" length="middle"/>
+<pin name="RST" x="-5.08" y="20.32" length="middle"/>
+<pin name="5V" x="20.32" y="2.54" length="middle" rot="R180"/>
+<pin name="GND" x="20.32" y="5.08" length="middle" rot="R180"/>
+<pin name="D4" x="20.32" y="7.62" length="middle" rot="R180"/>
+<pin name="D3" x="20.32" y="10.16" length="middle" rot="R180"/>
+<pin name="D2" x="20.32" y="12.7" length="middle" rot="R180"/>
+<pin name="D1" x="20.32" y="15.24" length="middle" rot="R180"/>
+<pin name="RX" x="20.32" y="17.78" length="middle" rot="R180"/>
+<pin name="TX" x="20.32" y="20.32" length="middle" rot="R180"/>
+<text x="0" y="23.622" size="1.27" layer="95">&gt;Name</text>
+<text x="0" y="-2.54" size="1.778" layer="96">&gt;Value</text>
+</symbol>
+</symbols>
+<devicesets>
+<deviceset name="WEMOS">
+<gates>
+<gate name="G$1" symbol="WEMOS" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="WEMOS">
+<connects>
+<connect gate="G$1" pin="3V3" pad="3V3"/>
+<connect gate="G$1" pin="5V" pad="5V"/>
+<connect gate="G$1" pin="A0" pad="A0"/>
+<connect gate="G$1" pin="D0" pad="D0"/>
+<connect gate="G$1" pin="D1" pad="D1"/>
+<connect gate="G$1" pin="D2" pad="D2"/>
+<connect gate="G$1" pin="D3" pad="D3"/>
+<connect gate="G$1" pin="D4" pad="D4"/>
+<connect gate="G$1" pin="D5" pad="D5"/>
+<connect gate="G$1" pin="D6" pad="D6"/>
+<connect gate="G$1" pin="D7" pad="D7"/>
+<connect gate="G$1" pin="D8" pad="D8"/>
+<connect gate="G$1" pin="GND" pad="GND"/>
+<connect gate="G$1" pin="RST" pad="RST"/>
+<connect gate="G$1" pin="RX" pad="RX"/>
+<connect gate="G$1" pin="TX" pad="TX"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+</devicesets>
+</library>
+<library name="con-wago-500">
+<description>&lt;b&gt;Wago Screw Clamps&lt;/b&gt;&lt;p&gt;
+Grid 5.00 mm&lt;p&gt;
+&lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
+<packages>
+<package name="W237-102">
+<description>&lt;b&gt;WAGO SCREW CLAMP&lt;/b&gt;</description>
+<wire x1="-3.491" y1="-2.286" x2="-1.484" y2="-0.279" width="0.254" layer="51"/>
+<wire x1="1.488" y1="-2.261" x2="3.469" y2="-0.254" width="0.254" layer="51"/>
+<wire x1="-4.989" y1="-5.461" x2="4.993" y2="-5.461" width="0.1524" layer="21"/>
+<wire x1="4.993" y1="3.734" x2="4.993" y2="3.531" width="0.1524" layer="21"/>
+<wire x1="4.993" y1="3.734" x2="-4.989" y2="3.734" width="0.1524" layer="21"/>
+<wire x1="-4.989" y1="-5.461" x2="-4.989" y2="-3.073" width="0.1524" layer="21"/>
+<wire x1="-4.989" y1="-3.073" x2="-3.389" y2="-3.073" width="0.1524" layer="21"/>
+<wire x1="-3.389" y1="-3.073" x2="-1.611" y2="-3.073" width="0.1524" layer="51"/>
+<wire x1="-1.611" y1="-3.073" x2="1.615" y2="-3.073" width="0.1524" layer="21"/>
+<wire x1="3.393" y1="-3.073" x2="4.993" y2="-3.073" width="0.1524" layer="21"/>
+<wire x1="-4.989" y1="-3.073" x2="-4.989" y2="3.531" width="0.1524" layer="21"/>
+<wire x1="4.993" y1="-3.073" x2="4.993" y2="-5.461" width="0.1524" layer="21"/>
+<wire x1="-4.989" y1="3.531" x2="4.993" y2="3.531" width="0.1524" layer="21"/>
+<wire x1="-4.989" y1="3.531" x2="-4.989" y2="3.734" width="0.1524" layer="21"/>
+<wire x1="4.993" y1="3.531" x2="4.993" y2="-3.073" width="0.1524" layer="21"/>
+<wire x1="1.615" y1="-3.073" x2="3.393" y2="-3.073" width="0.1524" layer="51"/>
+<circle x="-2.5" y="-1.27" radius="1.4986" width="0.1524" layer="51"/>
+<circle x="-2.5" y="2.2098" radius="0.508" width="0.1524" layer="21"/>
+<circle x="2.5038" y="-1.27" radius="1.4986" width="0.1524" layer="51"/>
+<circle x="2.5038" y="2.2098" radius="0.508" width="0.1524" layer="21"/>
+<pad name="1" x="-2.5" y="-1.27" drill="1.1938" shape="long" rot="R90"/>
+<pad name="2" x="2.5" y="-1.27" drill="1.1938" shape="long" rot="R90"/>
+<text x="-5.04" y="-7.62" size="1.27" layer="27" ratio="10">&gt;VALUE</text>
+<text x="-3.8462" y="-5.0038" size="1.27" layer="25" ratio="10">&gt;NAME</text>
+<text x="-4.532" y="0.635" size="1.27" layer="21" ratio="10">1</text>
+<text x="0.421" y="0.635" size="1.27" layer="21" ratio="10">2</text>
+</package>
+</packages>
+<symbols>
+<symbol name="KL">
+<circle x="1.27" y="0" radius="1.27" width="0.254" layer="94"/>
+<text x="0" y="0.889" size="1.778" layer="95" rot="R180">&gt;NAME</text>
+<pin name="KL" x="5.08" y="0" visible="off" length="short" direction="pas" rot="R180"/>
+</symbol>
+<symbol name="KL+V">
+<circle x="1.27" y="0" radius="1.27" width="0.254" layer="94"/>
+<text x="-2.54" y="-3.683" size="1.778" layer="96">&gt;VALUE</text>
+<text x="0" y="0.889" size="1.778" layer="95" rot="R180">&gt;NAME</text>
+<pin name="KL" x="5.08" y="0" visible="off" length="short" direction="pas" rot="R180"/>
+</symbol>
+</symbols>
+<devicesets>
+<deviceset name="W237-102" prefix="X" uservalue="yes">
+<description>&lt;b&gt;WAGO SCREW CLAMP&lt;/b&gt;</description>
+<gates>
+<gate name="-1" symbol="KL" x="0" y="5.08" addlevel="always"/>
+<gate name="-2" symbol="KL+V" x="0" y="0" addlevel="always"/>
+</gates>
+<devices>
+<device name="" package="W237-102">
+<connects>
+<connect gate="-1" pin="KL" pad="1"/>
+<connect gate="-2" pin="KL" pad="2"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="MF" value="" constant="no"/>
+<attribute name="MPN" value="237-102" constant="no"/>
+<attribute name="OC_FARNELL" value="unknown" constant="no"/>
+<attribute name="OC_NEWARK" value="70K9898" constant="no"/>
+</technology>
+</technologies>
+</device>
+</devices>
+</deviceset>
+</devicesets>
+</library>
+<library name="con-tycoelectronics">
+<description>&lt;b&gt;Tyco Electronics Connector&lt;/b&gt;&lt;p&gt;
+http://catalog.tycoelectronics.com&lt;br&gt;
+&lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
+<packages>
+<package name="RJ45-NO-SHIELD-NOLINE">
+<description>&lt;b&gt;RJ45 Low Profile&lt;/b&gt; No Shield&lt;p&gt;
+For all RJ45 N and Z Series Models&lt;br&gt;
+Source: www.tycoelectronics.com .. ENG_DS_1654001_1099_RJ_L_0507.pdf</description>
+<wire x1="-7.527" y1="10.819" x2="7.527" y2="10.819" width="0.2032" layer="21"/>
+<wire x1="7.527" y1="-7.782" x2="-7.527" y2="-7.782" width="0.2032" layer="21"/>
+<wire x1="-7.527" y1="-7.782" x2="-7.527" y2="10.819" width="0.2032" layer="21"/>
+<wire x1="7.527" y1="10.819" x2="7.527" y2="-7.782" width="0.2032" layer="21"/>
+<pad name="4" x="-0.635" y="8.89" drill="0.9" diameter="1.4"/>
+<pad name="3" x="-1.905" y="6.35" drill="0.9" diameter="1.4"/>
+<pad name="2" x="-3.175" y="8.89" drill="0.9" diameter="1.4"/>
+<pad name="5" x="0.635" y="6.35" drill="0.9" diameter="1.4"/>
+<pad name="1" x="-4.445" y="6.35" drill="0.9" diameter="1.4"/>
+<pad name="6" x="1.905" y="8.89" drill="0.9" diameter="1.4"/>
+<pad name="7" x="3.175" y="6.35" drill="0.9" diameter="1.4"/>
+<pad name="8" x="4.445" y="8.89" drill="0.9" diameter="1.4"/>
+<text x="-9.525" y="-0.635" size="1.778" layer="25" rot="R90">&gt;NAME</text>
+<text x="-5.715" y="2.54" size="1.778" layer="27">&gt;VALUE</text>
+<rectangle x1="7.6" y1="-5.485" x2="8.875" y2="-4.342" layer="21"/>
+<rectangle x1="-8.875" y1="-5.485" x2="-7.625" y2="-4.342" layer="21"/>
+<hole x="-5.715" y="0" drill="3.2512"/>
+<hole x="5.715" y="0" drill="3.2512"/>
+</package>
+</packages>
+<symbols>
+<symbol name="JACK8">
+<wire x1="1.524" y1="8.128" x2="0" y2="8.128" width="0.254" layer="94"/>
+<wire x1="0" y1="8.128" x2="0" y2="7.112" width="0.254" layer="94"/>
+<wire x1="0" y1="7.112" x2="1.524" y2="7.112" width="0.254" layer="94"/>
+<wire x1="1.524" y1="5.588" x2="0" y2="5.588" width="0.254" layer="94"/>
+<wire x1="0" y1="5.588" x2="0" y2="4.572" width="0.254" layer="94"/>
+<wire x1="0" y1="4.572" x2="1.524" y2="4.572" width="0.254" layer="94"/>
+<wire x1="1.524" y1="3.048" x2="0" y2="3.048" width="0.254" layer="94"/>
+<wire x1="0" y1="3.048" x2="0" y2="2.032" width="0.254" layer="94"/>
+<wire x1="0" y1="2.032" x2="1.524" y2="2.032" width="0.254" layer="94"/>
+<wire x1="1.524" y1="0.508" x2="0" y2="0.508" width="0.254" layer="94"/>
+<wire x1="0" y1="0.508" x2="0" y2="-0.508" width="0.254" layer="94"/>
+<wire x1="0" y1="-0.508" x2="1.524" y2="-0.508" width="0.254" layer="94"/>
+<wire x1="1.524" y1="-2.032" x2="0" y2="-2.032" width="0.254" layer="94"/>
+<wire x1="0" y1="-2.032" x2="0" y2="-3.048" width="0.254" layer="94"/>
+<wire x1="0" y1="-3.048" x2="1.524" y2="-3.048" width="0.254" layer="94"/>
+<wire x1="1.524" y1="-4.572" x2="0" y2="-4.572" width="0.254" layer="94"/>
+<wire x1="0" y1="-4.572" x2="0" y2="-5.588" width="0.254" layer="94"/>
+<wire x1="0" y1="-5.588" x2="1.524" y2="-5.588" width="0.254" layer="94"/>
+<wire x1="3.048" y1="-2.032" x2="5.588" y2="-2.032" width="0.1998" layer="94"/>
+<wire x1="5.588" y1="-2.032" x2="5.588" y2="-0.254" width="0.1998" layer="94"/>
+<wire x1="5.588" y1="-0.254" x2="6.604" y2="-0.254" width="0.1998" layer="94"/>
+<wire x1="6.604" y1="-0.254" x2="6.604" y2="1.778" width="0.1998" layer="94"/>
+<wire x1="6.604" y1="1.778" x2="5.588" y2="1.778" width="0.1998" layer="94"/>
+<wire x1="5.588" y1="1.778" x2="5.588" y2="3.556" width="0.1998" layer="94"/>
+<wire x1="5.588" y1="3.556" x2="3.048" y2="3.556" width="0.1998" layer="94"/>
+<wire x1="3.048" y1="3.556" x2="3.048" y2="2.54" width="0.1998" layer="94"/>
+<wire x1="3.048" y1="2.54" x2="3.048" y2="2.032" width="0.1998" layer="94"/>
+<wire x1="3.048" y1="2.032" x2="3.048" y2="1.524" width="0.1998" layer="94"/>
+<wire x1="3.048" y1="1.524" x2="3.048" y2="1.016" width="0.1998" layer="94"/>
+<wire x1="3.048" y1="1.016" x2="3.048" y2="0.508" width="0.1998" layer="94"/>
+<wire x1="3.048" y1="0.508" x2="3.048" y2="0" width="0.1998" layer="94"/>
+<wire x1="3.048" y1="0" x2="3.048" y2="-0.508" width="0.1998" layer="94"/>
+<wire x1="3.048" y1="-0.508" x2="3.048" y2="-1.016" width="0.1998" layer="94"/>
+<wire x1="3.048" y1="-1.016" x2="3.048" y2="-2.032" width="0.1998" layer="94"/>
+<wire x1="3.048" y1="2.54" x2="3.81" y2="2.54" width="0.1998" layer="94"/>
+<wire x1="3.048" y1="2.032" x2="3.81" y2="2.032" width="0.1998" layer="94"/>
+<wire x1="3.048" y1="1.524" x2="3.81" y2="1.524" width="0.1998" layer="94"/>
+<wire x1="3.048" y1="1.016" x2="3.81" y2="1.016" width="0.1998" layer="94"/>
+<wire x1="3.048" y1="0.508" x2="3.81" y2="0.508" width="0.1998" layer="94"/>
+<wire x1="3.048" y1="0" x2="3.81" y2="0" width="0.1998" layer="94"/>
+<wire x1="1.524" y1="-7.112" x2="0" y2="-7.112" width="0.254" layer="94"/>
+<wire x1="0" y1="-7.112" x2="0" y2="-8.128" width="0.254" layer="94"/>
+<wire x1="0" y1="-8.128" x2="1.524" y2="-8.128" width="0.254" layer="94"/>
+<wire x1="1.524" y1="-9.652" x2="0" y2="-9.652" width="0.254" layer="94"/>
+<wire x1="0" y1="-9.652" x2="0" y2="-10.668" width="0.254" layer="94"/>
+<wire x1="0" y1="-10.668" x2="1.524" y2="-10.668" width="0.254" layer="94"/>
+<wire x1="3.048" y1="-0.508" x2="3.81" y2="-0.508" width="0.1998" layer="94"/>
+<wire x1="3.048" y1="-1.016" x2="3.81" y2="-1.016" width="0.1998" layer="94"/>
+<text x="-2.54" y="10.16" size="1.778" layer="95">&gt;NAME</text>
+<text x="-2.54" y="-13.208" size="1.778" layer="96">&gt;VALUE</text>
+<pin name="1" x="-2.54" y="7.62" visible="pad" length="short" direction="pas" swaplevel="1"/>
+<pin name="2" x="-2.54" y="5.08" visible="pad" length="short" direction="pas" swaplevel="1"/>
+<pin name="3" x="-2.54" y="2.54" visible="pad" length="short" direction="pas" swaplevel="1"/>
+<pin name="4" x="-2.54" y="0" visible="pad" length="short" direction="pas" swaplevel="1"/>
+<pin name="5" x="-2.54" y="-2.54" visible="pad" length="short" direction="pas" swaplevel="1"/>
+<pin name="6" x="-2.54" y="-5.08" visible="pad" length="short" direction="pas" swaplevel="1"/>
+<pin name="7" x="-2.54" y="-7.62" visible="pad" length="short" direction="pas" swaplevel="1"/>
+<pin name="8" x="-2.54" y="-10.16" visible="pad" length="short" direction="pas" swaplevel="1"/>
+</symbol>
+</symbols>
+<devicesets>
+<deviceset name="RJ45" prefix="X">
+<description>&lt;b&gt;CORCOM Modular RJ Jacks&lt;/b&gt; No Shield&lt;p&gt;
+Source: www.tycoelectronics.com .. ENG_DS_1654001_1099_RJ_L_0507.pdf</description>
+<gates>
+<gate name="G$1" symbol="JACK8" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="RJ45-NO-SHIELD-NOLINE">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+<connect gate="G$1" pin="3" pad="3"/>
+<connect gate="G$1" pin="4" pad="4"/>
+<connect gate="G$1" pin="5" pad="5"/>
+<connect gate="G$1" pin="6" pad="6"/>
+<connect gate="G$1" pin="7" pad="7"/>
+<connect gate="G$1" pin="8" pad="8"/>
+</connects>
+<technologies>
+<technology name="-6L-B">
+<attribute name="MF" value="" constant="no"/>
+<attribute name="MPN" value="RJ45-6L-B" constant="no"/>
+<attribute name="OC_FARNELL" value="unknown" constant="no"/>
+<attribute name="OC_NEWARK" value="16R6090" constant="no"/>
+</technology>
+<technology name="-6L-S">
+<attribute name="MF" value="" constant="no"/>
+<attribute name="MPN" value="RJ45-6L-S" constant="no"/>
+<attribute name="OC_FARNELL" value="unknown" constant="no"/>
+<attribute name="OC_NEWARK" value="16R6091" constant="no"/>
+</technology>
+<technology name="-6X">
+<attribute name="MF" value="" constant="no"/>
+<attribute name="MPN" value="RJ45-6X" constant="no"/>
+<attribute name="OC_FARNELL" value="unknown" constant="no"/>
+<attribute name="OC_NEWARK" value="01P1604" constant="no"/>
+</technology>
+<technology name="-8L-B">
+<attribute name="MF" value="TYCO ELECTRONICS" constant="no"/>
+<attribute name="MPN" value="RJ45-8L-B" constant="no"/>
+<attribute name="OC_FARNELL" value="1279843" constant="no"/>
+<attribute name="OC_NEWARK" value="52K4445" constant="no"/>
+</technology>
+<technology name="-8L-S">
+<attribute name="MF" value="TYCO ELECTRONICS" constant="no"/>
+<attribute name="MPN" value="RJ45-8L-S" constant="no"/>
+<attribute name="OC_FARNELL" value="unknown" constant="no"/>
+<attribute name="OC_NEWARK" value="80K9067" constant="no"/>
+</technology>
+<technology name="-8X">
+<attribute name="MF" value="" constant="no"/>
+<attribute name="MPN" value="RJ45-8X" constant="no"/>
+<attribute name="OC_FARNELL" value="unknown" constant="no"/>
+<attribute name="OC_NEWARK" value="16R6101" constant="no"/>
+</technology>
+</technologies>
+</device>
+</devices>
+</deviceset>
+</devicesets>
+</library>
+<library name="pinhead">
+<description>&lt;b&gt;Pin Header Connectors&lt;/b&gt;&lt;p&gt;
+&lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
+<packages>
+<package name="1X02">
+<description>&lt;b&gt;PIN HEADER&lt;/b&gt;</description>
+<wire x1="-1.905" y1="1.27" x2="-0.635" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="-0.635" y1="1.27" x2="0" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="0" y1="0.635" x2="0" y2="-0.635" width="0.1524" layer="21"/>
+<wire x1="0" y1="-0.635" x2="-0.635" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="-2.54" y1="0.635" x2="-2.54" y2="-0.635" width="0.1524" layer="21"/>
+<wire x1="-1.905" y1="1.27" x2="-2.54" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="-2.54" y1="-0.635" x2="-1.905" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="-0.635" y1="-1.27" x2="-1.905" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="0" y1="0.635" x2="0.635" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="0.635" y1="1.27" x2="1.905" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="1.905" y1="1.27" x2="2.54" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="2.54" y1="0.635" x2="2.54" y2="-0.635" width="0.1524" layer="21"/>
+<wire x1="2.54" y1="-0.635" x2="1.905" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="1.905" y1="-1.27" x2="0.635" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="0.635" y1="-1.27" x2="0" y2="-0.635" width="0.1524" layer="21"/>
+<pad name="1" x="-1.27" y="0" drill="1.016" shape="long" rot="R90"/>
+<pad name="2" x="1.27" y="0" drill="1.016" shape="long" rot="R90"/>
+<text x="-2.6162" y="1.8288" size="1.27" layer="25" ratio="10">&gt;NAME</text>
+<text x="-2.54" y="-3.175" size="1.27" layer="27">&gt;VALUE</text>
+<rectangle x1="-1.524" y1="-0.254" x2="-1.016" y2="0.254" layer="51"/>
+<rectangle x1="1.016" y1="-0.254" x2="1.524" y2="0.254" layer="51"/>
+</package>
+<package name="1X02/90">
+<description>&lt;b&gt;PIN HEADER&lt;/b&gt;</description>
+<wire x1="-2.54" y1="-1.905" x2="0" y2="-1.905" width="0.1524" layer="21"/>
+<wire x1="0" y1="-1.905" x2="0" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="0" y1="0.635" x2="-2.54" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="-2.54" y1="0.635" x2="-2.54" y2="-1.905" width="0.1524" layer="21"/>
+<wire x1="-1.27" y1="6.985" x2="-1.27" y2="1.27" width="0.762" layer="21"/>
+<wire x1="0" y1="-1.905" x2="2.54" y2="-1.905" width="0.1524" layer="21"/>
+<wire x1="2.54" y1="-1.905" x2="2.54" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="2.54" y1="0.635" x2="0" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="1.27" y1="6.985" x2="1.27" y2="1.27" width="0.762" layer="21"/>
+<pad name="1" x="-1.27" y="-3.81" drill="1.016" shape="long" rot="R90"/>
+<pad name="2" x="1.27" y="-3.81" drill="1.016" shape="long" rot="R90"/>
+<text x="-3.175" y="-3.81" size="1.27" layer="25" ratio="10" rot="R90">&gt;NAME</text>
+<text x="4.445" y="-3.81" size="1.27" layer="27" rot="R90">&gt;VALUE</text>
+<rectangle x1="-1.651" y1="0.635" x2="-0.889" y2="1.143" layer="21"/>
+<rectangle x1="0.889" y1="0.635" x2="1.651" y2="1.143" layer="21"/>
+<rectangle x1="-1.651" y1="-2.921" x2="-0.889" y2="-1.905" layer="21"/>
+<rectangle x1="0.889" y1="-2.921" x2="1.651" y2="-1.905" layer="21"/>
+</package>
+</packages>
+<symbols>
+<symbol name="PINHD2">
+<wire x1="-6.35" y1="-2.54" x2="1.27" y2="-2.54" width="0.4064" layer="94"/>
+<wire x1="1.27" y1="-2.54" x2="1.27" y2="5.08" width="0.4064" layer="94"/>
+<wire x1="1.27" y1="5.08" x2="-6.35" y2="5.08" width="0.4064" layer="94"/>
+<wire x1="-6.35" y1="5.08" x2="-6.35" y2="-2.54" width="0.4064" layer="94"/>
+<text x="-6.35" y="5.715" size="1.778" layer="95">&gt;NAME</text>
+<text x="-6.35" y="-5.08" size="1.778" layer="96">&gt;VALUE</text>
+<pin name="1" x="-2.54" y="2.54" visible="pad" length="short" direction="pas" function="dot"/>
+<pin name="2" x="-2.54" y="0" visible="pad" length="short" direction="pas" function="dot"/>
+</symbol>
+</symbols>
+<devicesets>
+<deviceset name="PINHD-1X2" prefix="JP" uservalue="yes">
+<description>&lt;b&gt;PIN HEADER&lt;/b&gt;</description>
+<gates>
+<gate name="G$1" symbol="PINHD2" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="1X02">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="/90" package="1X02/90">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+</devicesets>
+</library>
+<library name="con-lstb">
+<description>&lt;b&gt;Pin Headers&lt;/b&gt;&lt;p&gt;
+Naming:&lt;p&gt;
+MA = male&lt;p&gt;
+# contacts - # rows&lt;p&gt;
+W = angled&lt;p&gt;
+&lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
+<packages>
+<package name="MA04-1">
+<description>&lt;b&gt;PIN HEADER&lt;/b&gt;</description>
+<wire x1="-4.445" y1="1.27" x2="-3.175" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="-3.175" y1="1.27" x2="-2.54" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="-2.54" y1="-0.635" x2="-3.175" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="-2.54" y1="0.635" x2="-1.905" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="-1.905" y1="1.27" x2="-0.635" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="-0.635" y1="1.27" x2="0" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="0" y1="-0.635" x2="-0.635" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="-0.635" y1="-1.27" x2="-1.905" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="-1.905" y1="-1.27" x2="-2.54" y2="-0.635" width="0.1524" layer="21"/>
+<wire x1="-5.08" y1="0.635" x2="-5.08" y2="-0.635" width="0.1524" layer="21"/>
+<wire x1="-4.445" y1="1.27" x2="-5.08" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="-5.08" y1="-0.635" x2="-4.445" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="-3.175" y1="-1.27" x2="-4.445" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="0" y1="0.635" x2="0.635" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="0.635" y1="1.27" x2="1.905" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="1.905" y1="1.27" x2="2.54" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="2.54" y1="-0.635" x2="1.905" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="1.905" y1="-1.27" x2="0.635" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="0.635" y1="-1.27" x2="0" y2="-0.635" width="0.1524" layer="21"/>
+<wire x1="3.175" y1="1.27" x2="4.445" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="4.445" y1="1.27" x2="5.08" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="5.08" y1="0.635" x2="5.08" y2="-0.635" width="0.1524" layer="21"/>
+<wire x1="5.08" y1="-0.635" x2="4.445" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="3.175" y1="1.27" x2="2.54" y2="0.635" width="0.1524" layer="21"/>
+<wire x1="2.54" y1="-0.635" x2="3.175" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="4.445" y1="-1.27" x2="3.175" y2="-1.27" width="0.1524" layer="21"/>
+<pad name="1" x="-3.81" y="0" drill="1.016" shape="long" rot="R90"/>
+<pad name="2" x="-1.27" y="0" drill="1.016" shape="long" rot="R90"/>
+<pad name="3" x="1.27" y="0" drill="1.016" shape="long" rot="R90"/>
+<pad name="4" x="3.81" y="0" drill="1.016" shape="long" rot="R90"/>
+<text x="-5.08" y="1.651" size="1.27" layer="25" ratio="10">&gt;NAME</text>
+<text x="-6.223" y="-0.635" size="1.27" layer="21" ratio="10">1</text>
+<text x="0.635" y="1.651" size="1.27" layer="27" ratio="10">&gt;VALUE</text>
+<text x="5.334" y="-0.635" size="1.27" layer="21" ratio="10">4</text>
+<rectangle x1="-1.524" y1="-0.254" x2="-1.016" y2="0.254" layer="51"/>
+<rectangle x1="-4.064" y1="-0.254" x2="-3.556" y2="0.254" layer="51"/>
+<rectangle x1="1.016" y1="-0.254" x2="1.524" y2="0.254" layer="51"/>
+<rectangle x1="3.556" y1="-0.254" x2="4.064" y2="0.254" layer="51"/>
+</package>
+</packages>
+<symbols>
+<symbol name="MA04-1">
+<wire x1="3.81" y1="-7.62" x2="-1.27" y2="-7.62" width="0.4064" layer="94"/>
+<wire x1="1.27" y1="0" x2="2.54" y2="0" width="0.6096" layer="94"/>
+<wire x1="1.27" y1="-2.54" x2="2.54" y2="-2.54" width="0.6096" layer="94"/>
+<wire x1="1.27" y1="-5.08" x2="2.54" y2="-5.08" width="0.6096" layer="94"/>
+<wire x1="-1.27" y1="5.08" x2="-1.27" y2="-7.62" width="0.4064" layer="94"/>
+<wire x1="3.81" y1="-7.62" x2="3.81" y2="5.08" width="0.4064" layer="94"/>
+<wire x1="-1.27" y1="5.08" x2="3.81" y2="5.08" width="0.4064" layer="94"/>
+<wire x1="1.27" y1="2.54" x2="2.54" y2="2.54" width="0.6096" layer="94"/>
+<text x="-1.27" y="-10.16" size="1.778" layer="96">&gt;VALUE</text>
+<text x="-1.27" y="5.842" size="1.778" layer="95">&gt;NAME</text>
+<pin name="1" x="7.62" y="-5.08" visible="pad" length="middle" direction="pas" swaplevel="1" rot="R180"/>
+<pin name="2" x="7.62" y="-2.54" visible="pad" length="middle" direction="pas" swaplevel="1" rot="R180"/>
+<pin name="3" x="7.62" y="0" visible="pad" length="middle" direction="pas" swaplevel="1" rot="R180"/>
+<pin name="4" x="7.62" y="2.54" visible="pad" length="middle" direction="pas" swaplevel="1" rot="R180"/>
+</symbol>
+</symbols>
+<devicesets>
+<deviceset name="MA04-1" prefix="SV" uservalue="yes">
+<description>&lt;b&gt;PIN HEADER&lt;/b&gt;</description>
+<gates>
+<gate name="1" symbol="MA04-1" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="MA04-1">
+<connects>
+<connect gate="1" pin="1" pad="1"/>
+<connect gate="1" pin="2" pad="2"/>
+<connect gate="1" pin="3" pad="3"/>
+<connect gate="1" pin="4" pad="4"/>
+</connects>
+<technologies>
+<technology name="">
+<attribute name="MF" value="" constant="no"/>
+<attribute name="MPN" value="" constant="no"/>
+<attribute name="OC_FARNELL" value="unknown" constant="no"/>
+<attribute name="OC_NEWARK" value="unknown" constant="no"/>
+</technology>
+</technologies>
+</device>
+</devices>
+</deviceset>
+</devicesets>
+</library>
+<library name="SparkFun-Resistors" urn="urn:adsk.eagle:library:532">
+<description>&lt;h3&gt;SparkFun Resistors&lt;/h3&gt;
+This library contains resistors. Reference designator:R. 
+&lt;br&gt;
+&lt;br&gt;
+We've spent an enormous amount of time creating and checking these footprints and parts, but it is &lt;b&gt; the end user's responsibility&lt;/b&gt; to ensure correctness and suitablity for a given componet or application. 
+&lt;br&gt;
+&lt;br&gt;If you enjoy using this library, please buy one of our products at &lt;a href=" www.sparkfun.com"&gt;SparkFun.com&lt;/a&gt;.
+&lt;br&gt;
+&lt;br&gt;
+&lt;b&gt;Licensing:&lt;/b&gt; Creative Commons ShareAlike 4.0 International - https://creativecommons.org/licenses/by-sa/4.0/ 
+&lt;br&gt;
+&lt;br&gt;
+You are welcome to use this library for commercial purposes. For attribution, we ask that when you begin to sell your device using our footprint, you email us with a link to the product being sold. We want bragging rights that we helped (in a very small part) to create your 8th world wonder. We would like the opportunity to feature your device on our homepage.</description>
+<packages>
+<package name="AXIAL-0.1" urn="urn:adsk.eagle:footprint:39620/1" library_version="1">
+<description>&lt;h3&gt;AXIAL-0.1&lt;/h3&gt;
+&lt;p&gt;Commonly used for 1/4W through-hole resistors. 0.1" pitch between holes.&lt;/p&gt;</description>
+<wire x1="0" y1="-0.762" x2="0" y2="0" width="0.2032" layer="21"/>
+<wire x1="0" y1="0" x2="0" y2="0.762" width="0.2032" layer="21"/>
+<wire x1="0.254" y1="0" x2="0" y2="0" width="0.2032" layer="21"/>
+<wire x1="0" y1="0" x2="-0.254" y2="0" width="0.2032" layer="21"/>
+<pad name="P$1" x="-1.27" y="0" drill="0.9" diameter="1.8796"/>
+<pad name="P$2" x="1.27" y="0" drill="0.9" diameter="1.8796"/>
+<text x="0" y="1.143" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;Name</text>
+<text x="0" y="-1.143" size="0.6096" layer="21" font="vector" ratio="20" align="top-center">&gt;Value</text>
+</package>
+<package name="AXIAL-0.3" urn="urn:adsk.eagle:footprint:39622/1" library_version="1">
+<description>&lt;h3&gt;AXIAL-0.3&lt;/h3&gt;
+&lt;p&gt;Commonly used for 1/4W through-hole resistors. 0.3" pitch between holes.&lt;/p&gt;</description>
+<wire x1="-2.54" y1="0.762" x2="2.54" y2="0.762" width="0.2032" layer="21"/>
+<wire x1="2.54" y1="0.762" x2="2.54" y2="0" width="0.2032" layer="21"/>
+<wire x1="2.54" y1="0" x2="2.54" y2="-0.762" width="0.2032" layer="21"/>
+<wire x1="2.54" y1="-0.762" x2="-2.54" y2="-0.762" width="0.2032" layer="21"/>
+<wire x1="-2.54" y1="-0.762" x2="-2.54" y2="0" width="0.2032" layer="21"/>
+<wire x1="-2.54" y1="0" x2="-2.54" y2="0.762" width="0.2032" layer="21"/>
+<wire x1="2.54" y1="0" x2="2.794" y2="0" width="0.2032" layer="21"/>
+<wire x1="-2.54" y1="0" x2="-2.794" y2="0" width="0.2032" layer="21"/>
+<pad name="P$1" x="-3.81" y="0" drill="0.9" diameter="1.8796"/>
+<pad name="P$2" x="3.81" y="0" drill="0.9" diameter="1.8796"/>
+<text x="0" y="1.016" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;Name</text>
+<text x="0" y="-1.016" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;Value</text>
+</package>
+<package name="AXIAL-0.1-KIT" urn="urn:adsk.eagle:footprint:39621/1" library_version="1">
+<description>&lt;h3&gt;AXIAL-0.1-KIT&lt;/h3&gt;
+&lt;p&gt;Commonly used for 1/4W through-hole resistors. 0.1" pitch between holes.&lt;/p&gt;
+&lt;p&gt;&lt;b&gt;Warning:&lt;/b&gt; This is the KIT version of the AXIAL-0.1 package. This package has a smaller diameter top stop mask, which doesn't cover the diameter of the pad. This means only the bottom side of the pads' copper will be exposed. You'll only be able to solder to the bottom side.&lt;/p&gt;</description>
+<wire x1="0" y1="-0.762" x2="0" y2="0" width="0.2032" layer="21"/>
+<wire x1="0" y1="0" x2="0" y2="0.762" width="0.2032" layer="21"/>
+<wire x1="0.254" y1="0" x2="0" y2="0" width="0.2032" layer="21"/>
+<wire x1="0" y1="0" x2="-0.254" y2="0" width="0.2032" layer="21"/>
+<pad name="P$1" x="-1.27" y="0" drill="0.9" diameter="1.8796" stop="no"/>
+<pad name="P$2" x="1.27" y="0" drill="0.9" diameter="1.8796" stop="no"/>
+<text x="0" y="1.143" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;Name</text>
+<text x="0" y="-1.143" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;Value</text>
+<circle x="-1.27" y="0" radius="0.4572" width="0" layer="29"/>
+<circle x="-1.27" y="0" radius="1.016" width="0" layer="30"/>
+<circle x="1.27" y="0" radius="1.016" width="0" layer="30"/>
+<circle x="-1.27" y="0" radius="0.4572" width="0" layer="29"/>
+<circle x="1.27" y="0" radius="0.4572" width="0" layer="29"/>
+</package>
+<package name="AXIAL-0.3-KIT" urn="urn:adsk.eagle:footprint:39623/1" library_version="1">
+<description>&lt;h3&gt;AXIAL-0.3-KIT&lt;/h3&gt;
+&lt;p&gt;Commonly used for 1/4W through-hole resistors. 0.3" pitch between holes.&lt;/p&gt;
+&lt;p&gt;&lt;b&gt;Warning:&lt;/b&gt; This is the KIT version of the AXIAL-0.3 package. This package has a smaller diameter top stop mask, which doesn't cover the diameter of the pad. This means only the bottom side of the pads' copper will be exposed. You'll only be able to solder to the bottom side.&lt;/p&gt;</description>
+<wire x1="-2.54" y1="1.27" x2="2.54" y2="1.27" width="0.254" layer="21"/>
+<wire x1="2.54" y1="1.27" x2="2.54" y2="0" width="0.254" layer="21"/>
+<wire x1="2.54" y1="0" x2="2.54" y2="-1.27" width="0.254" layer="21"/>
+<wire x1="2.54" y1="-1.27" x2="-2.54" y2="-1.27" width="0.254" layer="21"/>
+<wire x1="-2.54" y1="-1.27" x2="-2.54" y2="0" width="0.254" layer="21"/>
+<wire x1="-2.54" y1="0" x2="-2.54" y2="1.27" width="0.254" layer="21"/>
+<wire x1="2.54" y1="0" x2="2.794" y2="0" width="0.254" layer="21"/>
+<wire x1="-2.54" y1="0" x2="-2.794" y2="0" width="0.254" layer="21"/>
+<pad name="P$1" x="-3.81" y="0" drill="1.016" diameter="2.032" stop="no"/>
+<pad name="P$2" x="3.81" y="0" drill="1.016" diameter="2.032" stop="no"/>
+<text x="0" y="1.524" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;NAME</text>
+<text x="0" y="-1.524" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;VALUE</text>
+<polygon width="0.127" layer="30">
+<vertex x="3.8201" y="-0.9449" curve="-90"/>
+<vertex x="2.8652" y="-0.0152" curve="-90.011749"/>
+<vertex x="3.8176" y="0.9602" curve="-90"/>
+<vertex x="4.7676" y="-0.0178" curve="-90.024193"/>
+</polygon>
+<polygon width="0.127" layer="29">
+<vertex x="3.8176" y="-0.4369" curve="-90.012891"/>
+<vertex x="3.3731" y="-0.0127" curve="-90"/>
+<vertex x="3.8176" y="0.4546" curve="-90"/>
+<vertex x="4.2595" y="-0.0025" curve="-90.012967"/>
+</polygon>
+<polygon width="0.127" layer="30">
+<vertex x="-3.8075" y="-0.9525" curve="-90"/>
+<vertex x="-4.7624" y="-0.0228" curve="-90.011749"/>
+<vertex x="-3.81" y="0.9526" curve="-90"/>
+<vertex x="-2.86" y="-0.0254" curve="-90.024193"/>
+</polygon>
+<polygon width="0.127" layer="29">
+<vertex x="-3.81" y="-0.4445" curve="-90.012891"/>
+<vertex x="-4.2545" y="-0.0203" curve="-90"/>
+<vertex x="-3.81" y="0.447" curve="-90"/>
+<vertex x="-3.3681" y="-0.0101" curve="-90.012967"/>
+</polygon>
+</package>
+<package name="0603" urn="urn:adsk.eagle:footprint:39615/1" library_version="1">
+<description>&lt;p&gt;&lt;b&gt;Generic 1608 (0603) package&lt;/b&gt;&lt;/p&gt;
+&lt;p&gt;0.2mm courtyard excess rounded to nearest 0.05mm.&lt;/p&gt;</description>
+<wire x1="-1.6" y1="0.7" x2="1.6" y2="0.7" width="0.0508" layer="39"/>
+<wire x1="1.6" y1="0.7" x2="1.6" y2="-0.7" width="0.0508" layer="39"/>
+<wire x1="1.6" y1="-0.7" x2="-1.6" y2="-0.7" width="0.0508" layer="39"/>
+<wire x1="-1.6" y1="-0.7" x2="-1.6" y2="0.7" width="0.0508" layer="39"/>
+<wire x1="-0.356" y1="0.432" x2="0.356" y2="0.432" width="0.1016" layer="51"/>
+<wire x1="-0.356" y1="-0.419" x2="0.356" y2="-0.419" width="0.1016" layer="51"/>
+<smd name="1" x="-0.85" y="0" dx="1.1" dy="1" layer="1"/>
+<smd name="2" x="0.85" y="0" dx="1.1" dy="1" layer="1"/>
+<text x="0" y="0.762" size="0.6096" layer="25" font="vector" ratio="20" align="bottom-center">&gt;NAME</text>
+<text x="0" y="-0.762" size="0.6096" layer="27" font="vector" ratio="20" align="top-center">&gt;VALUE</text>
+<rectangle x1="-0.8382" y1="-0.4699" x2="-0.3381" y2="0.4801" layer="51"/>
+<rectangle x1="0.3302" y1="-0.4699" x2="0.8303" y2="0.4801" layer="51"/>
+<rectangle x1="-0.1999" y1="-0.3" x2="0.1999" y2="0.3" layer="35"/>
+</package>
+</packages>
+<packages3d>
+<package3d name="AXIAL-0.1" urn="urn:adsk.eagle:package:39656/1" type="box" library_version="1">
+<description>AXIAL-0.1
+Commonly used for 1/4W through-hole resistors. 0.1" pitch between holes.</description>
+<packageinstances>
+<packageinstance name="AXIAL-0.1"/>
+</packageinstances>
+</package3d>
+<package3d name="AXIAL-0.3" urn="urn:adsk.eagle:package:39658/1" type="box" library_version="1">
+<description>AXIAL-0.3
+Commonly used for 1/4W through-hole resistors. 0.3" pitch between holes.</description>
+<packageinstances>
+<packageinstance name="AXIAL-0.3"/>
+</packageinstances>
+</package3d>
+<package3d name="AXIAL-0.1-KIT" urn="urn:adsk.eagle:package:39653/1" type="box" library_version="1">
+<description>AXIAL-0.1-KIT
+Commonly used for 1/4W through-hole resistors. 0.1" pitch between holes.
+Warning: This is the KIT version of the AXIAL-0.1 package. This package has a smaller diameter top stop mask, which doesn't cover the diameter of the pad. This means only the bottom side of the pads' copper will be exposed. You'll only be able to solder to the bottom side.</description>
+<packageinstances>
+<packageinstance name="AXIAL-0.1-KIT"/>
+</packageinstances>
+</package3d>
+<package3d name="AXIAL-0.3-KIT" urn="urn:adsk.eagle:package:39661/1" type="box" library_version="1">
+<description>AXIAL-0.3-KIT
+Commonly used for 1/4W through-hole resistors. 0.3" pitch between holes.
+Warning: This is the KIT version of the AXIAL-0.3 package. This package has a smaller diameter top stop mask, which doesn't cover the diameter of the pad. This means only the bottom side of the pads' copper will be exposed. You'll only be able to solder to the bottom side.</description>
+<packageinstances>
+<packageinstance name="AXIAL-0.3-KIT"/>
+</packageinstances>
+</package3d>
+<package3d name="0603" urn="urn:adsk.eagle:package:39650/1" type="box" library_version="1">
+<description>Generic 1608 (0603) package
+0.2mm courtyard excess rounded to nearest 0.05mm.</description>
+<packageinstances>
+<packageinstance name="0603"/>
+</packageinstances>
+</package3d>
+</packages3d>
+<symbols>
+<symbol name="RESISTOR" urn="urn:adsk.eagle:symbol:39614/1" library_version="1">
+<wire x1="-2.54" y1="0" x2="-2.159" y2="1.016" width="0.1524" layer="94"/>
+<wire x1="-2.159" y1="1.016" x2="-1.524" y2="-1.016" width="0.1524" layer="94"/>
+<wire x1="-1.524" y1="-1.016" x2="-0.889" y2="1.016" width="0.1524" layer="94"/>
+<wire x1="-0.889" y1="1.016" x2="-0.254" y2="-1.016" width="0.1524" layer="94"/>
+<wire x1="-0.254" y1="-1.016" x2="0.381" y2="1.016" width="0.1524" layer="94"/>
+<wire x1="0.381" y1="1.016" x2="1.016" y2="-1.016" width="0.1524" layer="94"/>
+<wire x1="1.016" y1="-1.016" x2="1.651" y2="1.016" width="0.1524" layer="94"/>
+<wire x1="1.651" y1="1.016" x2="2.286" y2="-1.016" width="0.1524" layer="94"/>
+<wire x1="2.286" y1="-1.016" x2="2.54" y2="0" width="0.1524" layer="94"/>
+<text x="0" y="1.524" size="1.778" layer="95" font="vector" align="bottom-center">&gt;NAME</text>
+<text x="0" y="-1.524" size="1.778" layer="96" font="vector" align="top-center">&gt;VALUE</text>
+<pin name="2" x="5.08" y="0" visible="off" length="short" direction="pas" swaplevel="1" rot="R180"/>
+<pin name="1" x="-5.08" y="0" visible="off" length="short" direction="pas" swaplevel="1"/>
+</symbol>
+</symbols>
+<devicesets>
+<deviceset name="10KOHM" urn="urn:adsk.eagle:component:39764/1" prefix="R" library_version="1">
+<description>&lt;h3&gt;10kΩ resistor&lt;/h3&gt;
+&lt;p&gt;A resistor is a passive two-terminal electrical component that implements electrical resistance as a circuit element. Resistors act to reduce current flow, and, at the same time, act to lower voltage levels within circuits. - Wikipedia&lt;/p&gt;</description>
+<gates>
+<gate name="G$1" symbol="RESISTOR" x="0" y="0"/>
+</gates>
+<devices>
+<device name="-HORIZ-1/4W-1%" package="AXIAL-0.3">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:39658/1"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="RES-12183" constant="no"/>
+<attribute name="VALUE" value="10k" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="-VERT-1/4W-1%" package="AXIAL-0.1">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:39656/1"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="RES-12183"/>
+<attribute name="VALUE" value="10k"/>
+</technology>
+</technologies>
+</device>
+<device name="-VERT_KIT-1/4W-1%" package="AXIAL-0.1-KIT">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:39653/1"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="RES-12183" constant="no"/>
+<attribute name="VALUE" value="10k" constant="no"/>
+</technology>
+</technologies>
+</device>
+<device name="-VERT-1/4W-5%" package="AXIAL-0.1">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:39656/1"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="RES-09435"/>
+<attribute name="VALUE" value="10k"/>
+</technology>
+</technologies>
+</device>
+<device name="-VERT_KIT-1/4W-5%" package="AXIAL-0.1-KIT">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:39653/1"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="RES-09435"/>
+<attribute name="VALUE" value="10k"/>
+</technology>
+</technologies>
+</device>
+<device name="-HORIZ-1/4W-5%" package="AXIAL-0.3">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:39658/1"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="RES-09435"/>
+<attribute name="VALUE" value="10k"/>
+</technology>
+</technologies>
+</device>
+<device name="-HORIZ_KIT-1/4W-5%" package="AXIAL-0.3-KIT">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:39661/1"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="RES-09435"/>
+<attribute name="VALUE" value="10k"/>
+</technology>
+</technologies>
+</device>
+<device name="-HORIZ_KIT-1/4W-1%" package="AXIAL-0.3-KIT">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:39661/1"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="RES-12183"/>
+<attribute name="VALUE" value="10k"/>
+</technology>
+</technologies>
+</device>
+<device name="-VERT-1/6W-5%" package="AXIAL-0.1">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:39656/1"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="RES-08375"/>
+<attribute name="VALUE" value="10k"/>
+</technology>
+</technologies>
+</device>
+<device name="-VERT_KIT-1/6W-5%" package="AXIAL-0.1-KIT">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:39653/1"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="RES-08375"/>
+<attribute name="VALUE" value="10k"/>
+</technology>
+</technologies>
+</device>
+<device name="-HORIZ-1/6W-5%" package="AXIAL-0.3">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:39658/1"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="RES-08375"/>
+<attribute name="VALUE" value="10k"/>
+</technology>
+</technologies>
+</device>
+<device name="-HORIZ_KIT-1/6W-5%" package="AXIAL-0.3-KIT">
+<connects>
+<connect gate="G$1" pin="1" pad="P$1"/>
+<connect gate="G$1" pin="2" pad="P$2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:39661/1"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="RES-08375"/>
+<attribute name="VALUE" value="10k"/>
+</technology>
+</technologies>
+</device>
+<device name="-0603-1/10W-1%" package="0603">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:39650/1"/>
+</package3dinstances>
+<technologies>
+<technology name="">
+<attribute name="PROD_ID" value="RES-00824"/>
+<attribute name="VALUE" value="10k"/>
+</technology>
+</technologies>
+</device>
+</devices>
+</deviceset>
+</devicesets>
+</library>
+<library name="capacitor-wima" urn="urn:adsk.eagle:library:116">
+<description>&lt;b&gt;WIMA Capacitors&lt;/b&gt;&lt;p&gt;
+&lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;</description>
+<packages>
+<package name="C5B3" urn="urn:adsk.eagle:footprint:5380/1" library_version="1">
+<description>&lt;B&gt;MKS2&lt;/B&gt;, 7.5 x 3 mm, grid 5.08 mm</description>
+<wire x1="-0.3048" y1="0.635" x2="-0.3048" y2="0" width="0.3048" layer="21"/>
+<wire x1="-0.3048" y1="0" x2="-0.3048" y2="-0.635" width="0.3048" layer="21"/>
+<wire x1="-0.3048" y1="0" x2="-1.524" y2="0" width="0.1524" layer="21"/>
+<wire x1="0.3302" y1="0.635" x2="0.3302" y2="0" width="0.3048" layer="21"/>
+<wire x1="0.3302" y1="0" x2="0.3302" y2="-0.635" width="0.3048" layer="21"/>
+<wire x1="0.3302" y1="0" x2="1.524" y2="0" width="0.1524" layer="21"/>
+<wire x1="-3.683" y1="1.27" x2="-3.683" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="-3.429" y1="-1.524" x2="3.429" y2="-1.524" width="0.1524" layer="21"/>
+<wire x1="3.683" y1="-1.27" x2="3.683" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="3.429" y1="1.524" x2="-3.429" y2="1.524" width="0.1524" layer="21"/>
+<wire x1="3.429" y1="1.524" x2="3.683" y2="1.27" width="0.1524" layer="21" curve="-90"/>
+<wire x1="3.429" y1="-1.524" x2="3.683" y2="-1.27" width="0.1524" layer="21" curve="90"/>
+<wire x1="-3.683" y1="-1.27" x2="-3.429" y2="-1.524" width="0.1524" layer="21" curve="90"/>
+<wire x1="-3.683" y1="1.27" x2="-3.429" y2="1.524" width="0.1524" layer="21" curve="-90"/>
+<pad name="1" x="-2.54" y="0" drill="0.8128" diameter="1.6002" shape="octagon"/>
+<pad name="2" x="2.54" y="0" drill="0.8128" diameter="1.6002" shape="octagon"/>
+<text x="-2.54" y="1.778" size="1.27" layer="25" ratio="10">&gt;NAME</text>
+<text x="-2.54" y="-3.048" size="1.27" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="C10B4" urn="urn:adsk.eagle:footprint:5353/1" library_version="1">
+<description>&lt;B&gt;MKS4&lt;/B&gt;, 13.4 x 4 mm, grid 10.16 mm</description>
+<wire x1="-3.175" y1="1.27" x2="-3.175" y2="0" width="0.4064" layer="21"/>
+<wire x1="-2.286" y1="1.27" x2="-2.286" y2="0" width="0.4064" layer="21"/>
+<wire x1="3.81" y1="0" x2="-2.286" y2="0" width="0.1524" layer="21"/>
+<wire x1="-2.286" y1="0" x2="-2.286" y2="-1.27" width="0.4064" layer="21"/>
+<wire x1="-3.81" y1="0" x2="-3.175" y2="0" width="0.1524" layer="21"/>
+<wire x1="-3.175" y1="0" x2="-3.175" y2="-1.27" width="0.4064" layer="21"/>
+<wire x1="-6.096" y1="2.032" x2="6.096" y2="2.032" width="0.1524" layer="21"/>
+<wire x1="6.604" y1="1.524" x2="6.604" y2="-1.524" width="0.1524" layer="21"/>
+<wire x1="6.096" y1="-2.032" x2="-6.096" y2="-2.032" width="0.1524" layer="21"/>
+<wire x1="-6.604" y1="-1.524" x2="-6.604" y2="1.524" width="0.1524" layer="21"/>
+<wire x1="6.096" y1="2.032" x2="6.604" y2="1.524" width="0.1524" layer="21" curve="-90"/>
+<wire x1="6.096" y1="-2.032" x2="6.604" y2="-1.524" width="0.1524" layer="21" curve="90"/>
+<wire x1="-6.604" y1="-1.524" x2="-6.096" y2="-2.032" width="0.1524" layer="21" curve="90"/>
+<wire x1="-6.604" y1="1.524" x2="-6.096" y2="2.032" width="0.1524" layer="21" curve="-90"/>
+<pad name="1" x="-5.08" y="0" drill="1.016" diameter="2.159" shape="octagon"/>
+<pad name="2" x="5.08" y="0" drill="1.016" diameter="2.159" shape="octagon"/>
+<text x="-3.429" y="2.413" size="1.27" layer="25" ratio="10">&gt;NAME</text>
+<text x="-1.524" y="-1.651" size="1.27" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="C10B5" urn="urn:adsk.eagle:footprint:5354/1" library_version="1">
+<description>&lt;B&gt;MKS4&lt;/B&gt;, 13.4 x 5 mm, grid 10.16 mm</description>
+<wire x1="-3.175" y1="1.27" x2="-3.175" y2="0" width="0.4064" layer="21"/>
+<wire x1="-2.286" y1="1.27" x2="-2.286" y2="0" width="0.4064" layer="21"/>
+<wire x1="3.81" y1="0" x2="-2.286" y2="0" width="0.1524" layer="21"/>
+<wire x1="-2.286" y1="0" x2="-2.286" y2="-1.27" width="0.4064" layer="21"/>
+<wire x1="-3.81" y1="0" x2="-3.175" y2="0" width="0.1524" layer="21"/>
+<wire x1="-3.175" y1="0" x2="-3.175" y2="-1.27" width="0.4064" layer="21"/>
+<wire x1="-6.096" y1="2.54" x2="6.096" y2="2.54" width="0.1524" layer="21"/>
+<wire x1="6.604" y1="2.032" x2="6.604" y2="-2.032" width="0.1524" layer="21"/>
+<wire x1="6.096" y1="-2.54" x2="-6.096" y2="-2.54" width="0.1524" layer="21"/>
+<wire x1="-6.604" y1="-2.032" x2="-6.604" y2="2.032" width="0.1524" layer="21"/>
+<wire x1="6.096" y1="2.54" x2="6.604" y2="2.032" width="0.1524" layer="21" curve="-90"/>
+<wire x1="6.096" y1="-2.54" x2="6.604" y2="-2.032" width="0.1524" layer="21" curve="90"/>
+<wire x1="-6.604" y1="-2.032" x2="-6.096" y2="-2.54" width="0.1524" layer="21" curve="90"/>
+<wire x1="-6.604" y1="2.032" x2="-6.096" y2="2.54" width="0.1524" layer="21" curve="-90"/>
+<pad name="1" x="-5.08" y="0" drill="1.016" diameter="2.159" shape="octagon"/>
+<pad name="2" x="5.08" y="0" drill="1.016" diameter="2.159" shape="octagon"/>
+<text x="-5.08" y="2.794" size="1.27" layer="25" ratio="10">&gt;NAME</text>
+<text x="-1.524" y="-1.905" size="1.27" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="C10B6" urn="urn:adsk.eagle:footprint:5355/1" library_version="1">
+<description>&lt;B&gt;MKS4&lt;/B&gt;, 13.4 x 6 mm, grid 10.16 mm</description>
+<wire x1="-3.175" y1="1.27" x2="-3.175" y2="0" width="0.4064" layer="21"/>
+<wire x1="-2.286" y1="1.27" x2="-2.286" y2="0" width="0.4064" layer="21"/>
+<wire x1="3.81" y1="0" x2="-2.286" y2="0" width="0.1524" layer="21"/>
+<wire x1="-2.286" y1="0" x2="-2.286" y2="-1.27" width="0.4064" layer="21"/>
+<wire x1="-3.81" y1="0" x2="-3.175" y2="0" width="0.1524" layer="21"/>
+<wire x1="-3.175" y1="0" x2="-3.175" y2="-1.27" width="0.4064" layer="21"/>
+<wire x1="-6.096" y1="3.048" x2="6.096" y2="3.048" width="0.1524" layer="21"/>
+<wire x1="6.604" y1="2.54" x2="6.604" y2="-2.54" width="0.1524" layer="21"/>
+<wire x1="6.096" y1="-3.048" x2="-6.096" y2="-3.048" width="0.1524" layer="21"/>
+<wire x1="-6.604" y1="-2.54" x2="-6.604" y2="2.54" width="0.1524" layer="21"/>
+<wire x1="6.096" y1="3.048" x2="6.604" y2="2.54" width="0.1524" layer="21" curve="-90"/>
+<wire x1="6.096" y1="-3.048" x2="6.604" y2="-2.54" width="0.1524" layer="21" curve="90"/>
+<wire x1="-6.604" y1="-2.54" x2="-6.096" y2="-3.048" width="0.1524" layer="21" curve="90"/>
+<wire x1="-6.604" y1="2.54" x2="-6.096" y2="3.048" width="0.1524" layer="21" curve="-90"/>
+<pad name="1" x="-5.08" y="0" drill="1.016" diameter="2.159" shape="octagon"/>
+<pad name="2" x="5.08" y="0" drill="1.016" diameter="2.159" shape="octagon"/>
+<text x="-5.08" y="3.302" size="1.27" layer="25" ratio="10">&gt;NAME</text>
+<text x="-1.524" y="-2.032" size="1.27" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="C15B5" urn="urn:adsk.eagle:footprint:5356/1" library_version="1">
+<description>&lt;B&gt;MKS4&lt;/B&gt;, 18 x 5 mm, grid 15 mm</description>
+<wire x1="-5.08" y1="1.27" x2="-5.08" y2="0" width="0.4064" layer="21"/>
+<wire x1="-5.08" y1="0" x2="-5.08" y2="-1.27" width="0.4064" layer="21"/>
+<wire x1="-4.191" y1="1.27" x2="-4.191" y2="0" width="0.4064" layer="21"/>
+<wire x1="-4.191" y1="0" x2="-4.191" y2="-1.27" width="0.4064" layer="21"/>
+<wire x1="-4.191" y1="0" x2="6.096" y2="0" width="0.1524" layer="21"/>
+<wire x1="-5.08" y1="0" x2="-6.096" y2="0" width="0.1524" layer="21"/>
+<wire x1="9.017" y1="2.032" x2="9.017" y2="-2.032" width="0.1524" layer="21"/>
+<wire x1="8.509" y1="-2.54" x2="-8.509" y2="-2.54" width="0.1524" layer="21"/>
+<wire x1="-9.017" y1="-2.032" x2="-9.017" y2="2.032" width="0.1524" layer="21"/>
+<wire x1="-8.509" y1="2.54" x2="8.509" y2="2.54" width="0.1524" layer="21"/>
+<wire x1="8.509" y1="2.54" x2="9.017" y2="2.032" width="0.1524" layer="21" curve="-90"/>
+<wire x1="8.509" y1="-2.54" x2="9.017" y2="-2.032" width="0.1524" layer="21" curve="90"/>
+<wire x1="-9.017" y1="-2.032" x2="-8.509" y2="-2.54" width="0.1524" layer="21" curve="90"/>
+<wire x1="-9.017" y1="2.032" x2="-8.509" y2="2.54" width="0.1524" layer="21" curve="-90"/>
+<pad name="1" x="-7.493" y="0" drill="1.016" diameter="2.159" shape="octagon"/>
+<pad name="2" x="7.493" y="0" drill="1.016" diameter="2.159" shape="octagon"/>
+<text x="-7.493" y="2.794" size="1.397" layer="25" ratio="10">&gt;NAME</text>
+<text x="-3.429" y="-2.032" size="1.397" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="C15B6" urn="urn:adsk.eagle:footprint:5357/1" library_version="1">
+<description>&lt;B&gt;MKS4&lt;/B&gt;, 18 x 6 mm, grid 15 mm</description>
+<wire x1="-5.08" y1="1.27" x2="-5.08" y2="0" width="0.4064" layer="21"/>
+<wire x1="-5.08" y1="0" x2="-5.08" y2="-1.27" width="0.4064" layer="21"/>
+<wire x1="-4.191" y1="1.27" x2="-4.191" y2="0" width="0.4064" layer="21"/>
+<wire x1="-4.191" y1="0" x2="-4.191" y2="-1.27" width="0.4064" layer="21"/>
+<wire x1="-4.191" y1="0" x2="6.096" y2="0" width="0.1524" layer="21"/>
+<wire x1="-5.08" y1="0" x2="-6.096" y2="0" width="0.1524" layer="21"/>
+<wire x1="9.017" y1="2.54" x2="9.017" y2="-2.54" width="0.1524" layer="21"/>
+<wire x1="8.509" y1="-3.048" x2="-8.509" y2="-3.048" width="0.1524" layer="21"/>
+<wire x1="-9.017" y1="-2.54" x2="-9.017" y2="2.54" width="0.1524" layer="21"/>
+<wire x1="-8.509" y1="3.048" x2="8.509" y2="3.048" width="0.1524" layer="21"/>
+<wire x1="8.509" y1="3.048" x2="9.017" y2="2.54" width="0.1524" layer="21" curve="-90"/>
+<wire x1="8.509" y1="-3.048" x2="9.017" y2="-2.54" width="0.1524" layer="21" curve="90"/>
+<wire x1="-9.017" y1="-2.54" x2="-8.509" y2="-3.048" width="0.1524" layer="21" curve="90"/>
+<wire x1="-9.017" y1="2.54" x2="-8.509" y2="3.048" width="0.1524" layer="21" curve="-90"/>
+<pad name="1" x="-7.493" y="0" drill="1.016" diameter="2.159" shape="octagon"/>
+<pad name="2" x="7.493" y="0" drill="1.016" diameter="2.159" shape="octagon"/>
+<text x="-7.493" y="3.302" size="1.397" layer="25" ratio="10">&gt;NAME</text>
+<text x="-3.429" y="-2.032" size="1.397" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="C15B7" urn="urn:adsk.eagle:footprint:5358/1" library_version="1">
+<description>&lt;B&gt;MKS4&lt;/B&gt;, 18 x 7 mm, grid 15 mm</description>
+<wire x1="-5.08" y1="1.27" x2="-5.08" y2="0" width="0.4064" layer="21"/>
+<wire x1="-5.08" y1="0" x2="-5.08" y2="-1.27" width="0.4064" layer="21"/>
+<wire x1="-4.191" y1="1.27" x2="-4.191" y2="0" width="0.4064" layer="21"/>
+<wire x1="-4.191" y1="0" x2="-4.191" y2="-1.27" width="0.4064" layer="21"/>
+<wire x1="-4.191" y1="0" x2="6.096" y2="0" width="0.1524" layer="21"/>
+<wire x1="-5.08" y1="0" x2="-6.096" y2="0" width="0.1524" layer="21"/>
+<wire x1="9.017" y1="3.048" x2="9.017" y2="-3.048" width="0.1524" layer="21"/>
+<wire x1="8.509" y1="-3.556" x2="-8.509" y2="-3.556" width="0.1524" layer="21"/>
+<wire x1="-9.017" y1="-3.048" x2="-9.017" y2="3.048" width="0.1524" layer="21"/>
+<wire x1="-8.509" y1="3.556" x2="8.509" y2="3.556" width="0.1524" layer="21"/>
+<wire x1="8.509" y1="3.556" x2="9.017" y2="3.048" width="0.1524" layer="21" curve="-90"/>
+<wire x1="8.509" y1="-3.556" x2="9.017" y2="-3.048" width="0.1524" layer="21" curve="90"/>
+<wire x1="-9.017" y1="-3.048" x2="-8.509" y2="-3.556" width="0.1524" layer="21" curve="90"/>
+<wire x1="-9.017" y1="3.048" x2="-8.509" y2="3.556" width="0.1524" layer="21" curve="-90"/>
+<pad name="1" x="-7.493" y="0" drill="1.016" diameter="2.159" shape="octagon"/>
+<pad name="2" x="7.493" y="0" drill="1.016" diameter="2.159" shape="octagon"/>
+<text x="-7.493" y="3.81" size="1.397" layer="25" ratio="10">&gt;NAME</text>
+<text x="-3.429" y="-2.286" size="1.397" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="C15B8" urn="urn:adsk.eagle:footprint:5359/1" library_version="1">
+<description>&lt;B&gt;MKS4&lt;/B&gt;, 18 x 8 mm, grid 15 mm</description>
+<wire x1="-5.08" y1="1.27" x2="-5.08" y2="0" width="0.4064" layer="21"/>
+<wire x1="-5.08" y1="0" x2="-5.08" y2="-1.27" width="0.4064" layer="21"/>
+<wire x1="-4.191" y1="1.27" x2="-4.191" y2="0" width="0.4064" layer="21"/>
+<wire x1="-4.191" y1="0" x2="-4.191" y2="-1.27" width="0.4064" layer="21"/>
+<wire x1="-4.191" y1="0" x2="6.096" y2="0" width="0.1524" layer="21"/>
+<wire x1="-5.08" y1="0" x2="-6.096" y2="0" width="0.1524" layer="21"/>
+<wire x1="9.017" y1="3.556" x2="9.017" y2="-3.556" width="0.1524" layer="21"/>
+<wire x1="8.509" y1="-4.064" x2="-8.509" y2="-4.064" width="0.1524" layer="21"/>
+<wire x1="-9.017" y1="-3.556" x2="-9.017" y2="3.556" width="0.1524" layer="21"/>
+<wire x1="-8.509" y1="4.064" x2="8.509" y2="4.064" width="0.1524" layer="21"/>
+<wire x1="8.509" y1="4.064" x2="9.017" y2="3.556" width="0.1524" layer="21" curve="-90"/>
+<wire x1="8.509" y1="-4.064" x2="9.017" y2="-3.556" width="0.1524" layer="21" curve="90"/>
+<wire x1="-9.017" y1="-3.556" x2="-8.509" y2="-4.064" width="0.1524" layer="21" curve="90"/>
+<wire x1="-9.017" y1="3.556" x2="-8.509" y2="4.064" width="0.1524" layer="21" curve="-90"/>
+<pad name="1" x="-7.493" y="0" drill="1.016" diameter="2.159" shape="octagon"/>
+<pad name="2" x="7.493" y="0" drill="1.016" diameter="2.159" shape="octagon"/>
+<text x="-7.493" y="4.318" size="1.397" layer="25" ratio="10">&gt;NAME</text>
+<text x="-3.429" y="-2.54" size="1.397" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="C15B9" urn="urn:adsk.eagle:footprint:5360/1" library_version="1">
+<description>&lt;B&gt;MKS4&lt;/B&gt;, 18 x 9 mm, grid 15 mm</description>
+<wire x1="-5.08" y1="1.27" x2="-5.08" y2="0" width="0.4064" layer="21"/>
+<wire x1="-5.08" y1="0" x2="-5.08" y2="-1.27" width="0.4064" layer="21"/>
+<wire x1="-4.191" y1="1.27" x2="-4.191" y2="0" width="0.4064" layer="21"/>
+<wire x1="-4.191" y1="0" x2="-4.191" y2="-1.27" width="0.4064" layer="21"/>
+<wire x1="-4.191" y1="0" x2="6.096" y2="0" width="0.1524" layer="21"/>
+<wire x1="-5.08" y1="0" x2="-6.096" y2="0" width="0.1524" layer="21"/>
+<wire x1="9.017" y1="3.937" x2="9.017" y2="-3.937" width="0.1524" layer="21"/>
+<wire x1="8.509" y1="-4.445" x2="-8.509" y2="-4.445" width="0.1524" layer="21"/>
+<wire x1="-9.017" y1="-3.937" x2="-9.017" y2="3.937" width="0.1524" layer="21"/>
+<wire x1="-8.509" y1="4.445" x2="8.509" y2="4.445" width="0.1524" layer="21"/>
+<wire x1="8.509" y1="4.445" x2="9.017" y2="3.937" width="0.1524" layer="21" curve="-90"/>
+<wire x1="8.509" y1="-4.445" x2="9.017" y2="-3.937" width="0.1524" layer="21" curve="90"/>
+<wire x1="-9.017" y1="-3.937" x2="-8.509" y2="-4.445" width="0.1524" layer="21" curve="90"/>
+<wire x1="-9.017" y1="3.937" x2="-8.509" y2="4.445" width="0.1524" layer="21" curve="-90"/>
+<pad name="1" x="-7.493" y="0" drill="1.016" diameter="2.159" shape="octagon"/>
+<pad name="2" x="7.493" y="0" drill="1.016" diameter="2.159" shape="octagon"/>
+<text x="-7.493" y="4.699" size="1.397" layer="25" ratio="10">&gt;NAME</text>
+<text x="-3.429" y="-2.54" size="1.397" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="C2.5-2" urn="urn:adsk.eagle:footprint:5361/1" library_version="1">
+<description>&lt;B&gt;MKS2&lt;/B&gt;, 5 x 2.5 mm, grid 2.54 mm</description>
+<wire x1="-2.159" y1="1.27" x2="2.159" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="2.159" y1="-1.27" x2="-2.159" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="2.413" y1="1.016" x2="2.413" y2="-1.016" width="0.1524" layer="21"/>
+<wire x1="-2.413" y1="1.016" x2="-2.413" y2="-1.016" width="0.1524" layer="21"/>
+<wire x1="2.159" y1="1.27" x2="2.413" y2="1.016" width="0.1524" layer="21" curve="-90"/>
+<wire x1="-2.413" y1="1.016" x2="-2.159" y2="1.27" width="0.1524" layer="21" curve="-90"/>
+<wire x1="2.159" y1="-1.27" x2="2.413" y2="-1.016" width="0.1524" layer="21" curve="90"/>
+<wire x1="-2.413" y1="-1.016" x2="-2.159" y2="-1.27" width="0.1524" layer="21" curve="90"/>
+<wire x1="1.27" y1="0" x2="0.381" y2="0" width="0.1524" layer="51"/>
+<wire x1="0.381" y1="0" x2="0.254" y2="0" width="0.1524" layer="21"/>
+<wire x1="0.254" y1="0" x2="0.254" y2="0.762" width="0.254" layer="21"/>
+<wire x1="0.254" y1="0" x2="0.254" y2="-0.762" width="0.254" layer="21"/>
+<wire x1="-0.254" y1="0.762" x2="-0.254" y2="0" width="0.254" layer="21"/>
+<wire x1="-0.254" y1="0" x2="-0.254" y2="-0.762" width="0.254" layer="21"/>
+<wire x1="-0.254" y1="0" x2="-0.381" y2="0" width="0.1524" layer="21"/>
+<wire x1="-0.381" y1="0" x2="-1.27" y2="0" width="0.1524" layer="51"/>
+<pad name="1" x="-1.27" y="0" drill="0.8128" diameter="1.6002" shape="octagon"/>
+<pad name="2" x="1.27" y="0" drill="0.8128" diameter="1.6002" shape="octagon"/>
+<text x="-1.651" y="1.524" size="1.27" layer="25" ratio="10">&gt;NAME</text>
+<text x="-1.651" y="-2.794" size="1.27" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="C2.5-4" urn="urn:adsk.eagle:footprint:5362/1" library_version="1">
+<description>&lt;B&gt;MKS2&lt;/B&gt;, 5 x 4 mm, grid 2.54 mm</description>
+<wire x1="-2.159" y1="1.905" x2="2.159" y2="1.905" width="0.1524" layer="21"/>
+<wire x1="2.159" y1="-1.905" x2="-2.159" y2="-1.905" width="0.1524" layer="21"/>
+<wire x1="2.413" y1="1.651" x2="2.413" y2="-1.651" width="0.1524" layer="21"/>
+<wire x1="-2.413" y1="1.651" x2="-2.413" y2="-1.651" width="0.1524" layer="21"/>
+<wire x1="2.159" y1="1.905" x2="2.413" y2="1.651" width="0.1524" layer="21" curve="-90"/>
+<wire x1="-2.413" y1="1.651" x2="-2.159" y2="1.905" width="0.1524" layer="21" curve="-90"/>
+<wire x1="2.159" y1="-1.905" x2="2.413" y2="-1.651" width="0.1524" layer="21" curve="90"/>
+<wire x1="-2.413" y1="-1.651" x2="-2.159" y2="-1.905" width="0.1524" layer="21" curve="90"/>
+<wire x1="1.27" y1="0" x2="0.381" y2="0" width="0.1524" layer="51"/>
+<wire x1="0.381" y1="0" x2="0.254" y2="0" width="0.1524" layer="21"/>
+<wire x1="0.254" y1="0" x2="0.254" y2="0.762" width="0.254" layer="21"/>
+<wire x1="0.254" y1="0" x2="0.254" y2="-0.762" width="0.254" layer="21"/>
+<wire x1="-0.254" y1="0.762" x2="-0.254" y2="0" width="0.254" layer="21"/>
+<wire x1="-0.254" y1="0" x2="-0.254" y2="-0.762" width="0.254" layer="21"/>
+<wire x1="-0.254" y1="0" x2="-0.381" y2="0" width="0.1524" layer="21"/>
+<wire x1="-0.381" y1="0" x2="-1.27" y2="0" width="0.1524" layer="51"/>
+<pad name="1" x="-1.27" y="0" drill="0.8128" diameter="1.6002" shape="octagon"/>
+<pad name="2" x="1.27" y="0" drill="0.8128" diameter="1.6002" shape="octagon"/>
+<text x="-1.651" y="2.159" size="1.27" layer="25" ratio="10">&gt;NAME</text>
+<text x="-1.651" y="-3.429" size="1.27" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="C2.5-5" urn="urn:adsk.eagle:footprint:5363/1" library_version="1">
+<description>&lt;B&gt;MKS2&lt;/B&gt;, 5 x 5 mm, grid 2.54 mm</description>
+<wire x1="-2.159" y1="2.286" x2="2.159" y2="2.286" width="0.1524" layer="21"/>
+<wire x1="2.159" y1="-2.286" x2="-2.159" y2="-2.286" width="0.1524" layer="21"/>
+<wire x1="2.413" y1="2.032" x2="2.413" y2="-2.032" width="0.1524" layer="21"/>
+<wire x1="-2.413" y1="2.032" x2="-2.413" y2="-2.032" width="0.1524" layer="21"/>
+<wire x1="2.159" y1="2.286" x2="2.413" y2="2.032" width="0.1524" layer="21" curve="-90"/>
+<wire x1="-2.413" y1="2.032" x2="-2.159" y2="2.286" width="0.1524" layer="21" curve="-90"/>
+<wire x1="2.159" y1="-2.286" x2="2.413" y2="-2.032" width="0.1524" layer="21" curve="90"/>
+<wire x1="-2.413" y1="-2.032" x2="-2.159" y2="-2.286" width="0.1524" layer="21" curve="90"/>
+<wire x1="1.27" y1="0" x2="0.381" y2="0" width="0.1524" layer="51"/>
+<wire x1="0.381" y1="0" x2="0.254" y2="0" width="0.1524" layer="21"/>
+<wire x1="0.254" y1="0" x2="0.254" y2="0.762" width="0.254" layer="21"/>
+<wire x1="0.254" y1="0" x2="0.254" y2="-0.762" width="0.254" layer="21"/>
+<wire x1="-0.254" y1="0.762" x2="-0.254" y2="0" width="0.254" layer="21"/>
+<wire x1="-0.254" y1="0" x2="-0.254" y2="-0.762" width="0.254" layer="21"/>
+<wire x1="-0.254" y1="0" x2="-0.381" y2="0" width="0.1524" layer="21"/>
+<wire x1="-0.381" y1="0" x2="-1.27" y2="0" width="0.1524" layer="51"/>
+<pad name="1" x="-1.27" y="0" drill="0.8128" diameter="1.6002" shape="octagon"/>
+<pad name="2" x="1.27" y="0" drill="0.8128" diameter="1.6002" shape="octagon"/>
+<text x="-1.778" y="2.54" size="1.27" layer="25" ratio="10">&gt;NAME</text>
+<text x="-1.778" y="-3.81" size="1.27" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="C2.5-6" urn="urn:adsk.eagle:footprint:5364/1" library_version="1">
+<description>&lt;B&gt;MKS2&lt;/B&gt;, 5 x 6 mm, grid 2.54 mm</description>
+<wire x1="-2.159" y1="2.794" x2="2.159" y2="2.794" width="0.1524" layer="21"/>
+<wire x1="2.159" y1="-2.794" x2="-2.159" y2="-2.794" width="0.1524" layer="21"/>
+<wire x1="2.413" y1="2.54" x2="2.413" y2="-2.54" width="0.1524" layer="21"/>
+<wire x1="-2.413" y1="2.54" x2="-2.413" y2="-2.54" width="0.1524" layer="21"/>
+<wire x1="2.159" y1="2.794" x2="2.413" y2="2.54" width="0.1524" layer="21" curve="-90"/>
+<wire x1="-2.413" y1="2.54" x2="-2.159" y2="2.794" width="0.1524" layer="21" curve="-90"/>
+<wire x1="2.159" y1="-2.794" x2="2.413" y2="-2.54" width="0.1524" layer="21" curve="90"/>
+<wire x1="-2.413" y1="-2.54" x2="-2.159" y2="-2.794" width="0.1524" layer="21" curve="90"/>
+<wire x1="1.27" y1="0" x2="0.381" y2="0" width="0.1524" layer="51"/>
+<wire x1="0.381" y1="0" x2="0.254" y2="0" width="0.1524" layer="21"/>
+<wire x1="0.254" y1="0" x2="0.254" y2="0.762" width="0.254" layer="21"/>
+<wire x1="0.254" y1="0" x2="0.254" y2="-0.762" width="0.254" layer="21"/>
+<wire x1="-0.254" y1="0.762" x2="-0.254" y2="0" width="0.254" layer="21"/>
+<wire x1="-0.254" y1="0" x2="-0.254" y2="-0.762" width="0.254" layer="21"/>
+<wire x1="-0.254" y1="0" x2="-0.381" y2="0" width="0.1524" layer="21"/>
+<wire x1="-0.381" y1="0" x2="-1.27" y2="0" width="0.1524" layer="51"/>
+<pad name="1" x="-1.27" y="0" drill="0.8128" diameter="1.6002" shape="octagon"/>
+<pad name="2" x="1.27" y="0" drill="0.8128" diameter="1.6002" shape="octagon"/>
+<text x="2.667" y="0.762" size="1.27" layer="25" ratio="10">&gt;NAME</text>
+<text x="-1.905" y="-2.413" size="1.27" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="C22.5B10" urn="urn:adsk.eagle:footprint:5365/1" library_version="1">
+<description>&lt;B&gt;MKS4&lt;/B&gt;, 27 x 10 mm, grid 22.5 mm</description>
+<wire x1="-12.827" y1="5.334" x2="12.827" y2="5.334" width="0.1524" layer="21"/>
+<wire x1="13.335" y1="4.826" x2="13.335" y2="-4.826" width="0.1524" layer="21"/>
+<wire x1="12.827" y1="-5.334" x2="-12.827" y2="-5.334" width="0.1524" layer="21"/>
+<wire x1="-13.335" y1="-4.826" x2="-13.335" y2="4.826" width="0.1524" layer="21"/>
+<wire x1="-6.731" y1="1.905" x2="-6.731" y2="0" width="0.4064" layer="21"/>
+<wire x1="-6.731" y1="0" x2="-6.731" y2="-1.905" width="0.4064" layer="21"/>
+<wire x1="-7.62" y1="1.905" x2="-7.62" y2="0" width="0.4064" layer="21"/>
+<wire x1="-7.62" y1="0" x2="-7.62" y2="-1.905" width="0.4064" layer="21"/>
+<wire x1="12.827" y1="5.334" x2="13.335" y2="4.826" width="0.1524" layer="21" curve="-90"/>
+<wire x1="12.827" y1="-5.334" x2="13.335" y2="-4.826" width="0.1524" layer="21" curve="90"/>
+<wire x1="-13.335" y1="-4.826" x2="-12.827" y2="-5.334" width="0.1524" layer="21" curve="90"/>
+<wire x1="-13.335" y1="4.826" x2="-12.827" y2="5.334" width="0.1524" layer="21" curve="-90"/>
+<wire x1="-9.652" y1="0" x2="-7.62" y2="0" width="0.1524" layer="21"/>
+<wire x1="-6.731" y1="0" x2="9.652" y2="0" width="0.1524" layer="21"/>
+<pad name="1" x="-11.303" y="0" drill="1.016" diameter="2.54" shape="octagon"/>
+<pad name="2" x="11.303" y="0" drill="1.016" diameter="2.54" shape="octagon"/>
+<text x="-11.303" y="5.588" size="1.778" layer="25" ratio="10">&gt;NAME</text>
+<text x="-5.08" y="-2.54" size="1.778" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="C22.5B11" urn="urn:adsk.eagle:footprint:5366/1" library_version="1">
+<description>&lt;B&gt;MKS4&lt;/B&gt;, 27 x 11 mm, grid 22.5 mm</description>
+<wire x1="-12.827" y1="5.588" x2="12.827" y2="5.588" width="0.1524" layer="21"/>
+<wire x1="13.335" y1="5.08" x2="13.335" y2="-5.08" width="0.1524" layer="21"/>
+<wire x1="12.827" y1="-5.588" x2="-12.827" y2="-5.588" width="0.1524" layer="21"/>
+<wire x1="-13.335" y1="-5.08" x2="-13.335" y2="5.08" width="0.1524" layer="21"/>
+<wire x1="-6.731" y1="1.905" x2="-6.731" y2="0" width="0.4064" layer="21"/>
+<wire x1="-6.731" y1="0" x2="-6.731" y2="-1.905" width="0.4064" layer="21"/>
+<wire x1="-7.62" y1="1.905" x2="-7.62" y2="0" width="0.4064" layer="21"/>
+<wire x1="-7.62" y1="0" x2="-7.62" y2="-1.905" width="0.4064" layer="21"/>
+<wire x1="12.827" y1="5.588" x2="13.335" y2="5.08" width="0.1524" layer="21" curve="-90"/>
+<wire x1="12.827" y1="-5.588" x2="13.335" y2="-5.08" width="0.1524" layer="21" curve="90"/>
+<wire x1="-13.335" y1="-5.08" x2="-12.827" y2="-5.588" width="0.1524" layer="21" curve="90"/>
+<wire x1="-13.335" y1="5.08" x2="-12.827" y2="5.588" width="0.1524" layer="21" curve="-90"/>
+<wire x1="-9.652" y1="0" x2="-7.62" y2="0" width="0.1524" layer="21"/>
+<wire x1="-6.731" y1="0" x2="9.652" y2="0" width="0.1524" layer="21"/>
+<pad name="1" x="-11.303" y="0" drill="1.016" diameter="2.54" shape="octagon"/>
+<pad name="2" x="11.303" y="0" drill="1.016" diameter="2.54" shape="octagon"/>
+<text x="-11.303" y="5.842" size="1.778" layer="25" ratio="10">&gt;NAME</text>
+<text x="-5.08" y="-2.54" size="1.778" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="C22.5B6" urn="urn:adsk.eagle:footprint:5367/1" library_version="1">
+<description>&lt;B&gt;MKS4&lt;/B&gt;, 27 x 6 mm, grid 22.5 mm</description>
+<wire x1="-12.827" y1="3.048" x2="12.827" y2="3.048" width="0.1524" layer="21"/>
+<wire x1="13.335" y1="2.54" x2="13.335" y2="-2.54" width="0.1524" layer="21"/>
+<wire x1="12.827" y1="-3.048" x2="-12.827" y2="-3.048" width="0.1524" layer="21"/>
+<wire x1="-13.335" y1="-2.54" x2="-13.335" y2="2.54" width="0.1524" layer="21"/>
+<wire x1="-6.731" y1="1.905" x2="-6.731" y2="0" width="0.4064" layer="21"/>
+<wire x1="-6.731" y1="0" x2="-6.731" y2="-1.905" width="0.4064" layer="21"/>
+<wire x1="-7.62" y1="1.905" x2="-7.62" y2="0" width="0.4064" layer="21"/>
+<wire x1="-7.62" y1="0" x2="-7.62" y2="-1.905" width="0.4064" layer="21"/>
+<wire x1="12.827" y1="3.048" x2="13.335" y2="2.54" width="0.1524" layer="21" curve="-90"/>
+<wire x1="12.827" y1="-3.048" x2="13.335" y2="-2.54" width="0.1524" layer="21" curve="90"/>
+<wire x1="-13.335" y1="-2.54" x2="-12.827" y2="-3.048" width="0.1524" layer="21" curve="90"/>
+<wire x1="-13.335" y1="2.54" x2="-12.827" y2="3.048" width="0.1524" layer="21" curve="-90"/>
+<wire x1="-9.652" y1="0" x2="-7.62" y2="0" width="0.1524" layer="21"/>
+<wire x1="-6.731" y1="0" x2="9.652" y2="0" width="0.1524" layer="21"/>
+<pad name="1" x="-11.303" y="0" drill="1.016" diameter="2.54" shape="octagon"/>
+<pad name="2" x="11.303" y="0" drill="1.016" diameter="2.54" shape="octagon"/>
+<text x="-11.303" y="3.302" size="1.778" layer="25" ratio="10">&gt;NAME</text>
+<text x="-5.08" y="-2.54" size="1.778" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="C22.5B7" urn="urn:adsk.eagle:footprint:5368/1" library_version="1">
+<description>&lt;B&gt;MKS4&lt;/B&gt;, 27 x 7 mm, grid 22.5 mm</description>
+<wire x1="-12.827" y1="3.556" x2="12.827" y2="3.556" width="0.1524" layer="21"/>
+<wire x1="13.335" y1="3.048" x2="13.335" y2="-3.048" width="0.1524" layer="21"/>
+<wire x1="12.827" y1="-3.556" x2="-12.827" y2="-3.556" width="0.1524" layer="21"/>
+<wire x1="-13.335" y1="-3.048" x2="-13.335" y2="3.048" width="0.1524" layer="21"/>
+<wire x1="-6.731" y1="1.905" x2="-6.731" y2="0" width="0.4064" layer="21"/>
+<wire x1="-6.731" y1="0" x2="-6.731" y2="-1.905" width="0.4064" layer="21"/>
+<wire x1="-7.62" y1="1.905" x2="-7.62" y2="0" width="0.4064" layer="21"/>
+<wire x1="-7.62" y1="0" x2="-7.62" y2="-1.905" width="0.4064" layer="21"/>
+<wire x1="12.827" y1="3.556" x2="13.335" y2="3.048" width="0.1524" layer="21" curve="-90"/>
+<wire x1="12.827" y1="-3.556" x2="13.335" y2="-3.048" width="0.1524" layer="21" curve="90"/>
+<wire x1="-13.335" y1="-3.048" x2="-12.827" y2="-3.556" width="0.1524" layer="21" curve="90"/>
+<wire x1="-13.335" y1="3.048" x2="-12.827" y2="3.556" width="0.1524" layer="21" curve="-90"/>
+<wire x1="-9.652" y1="0" x2="-7.62" y2="0" width="0.1524" layer="21"/>
+<wire x1="-6.731" y1="0" x2="9.652" y2="0" width="0.1524" layer="21"/>
+<pad name="1" x="-11.303" y="0" drill="1.016" diameter="2.54" shape="octagon"/>
+<pad name="2" x="11.303" y="0" drill="1.016" diameter="2.54" shape="octagon"/>
+<text x="-11.303" y="3.81" size="1.778" layer="25" ratio="10">&gt;NAME</text>
+<text x="-5.08" y="-2.54" size="1.778" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="C22.5B8" urn="urn:adsk.eagle:footprint:5369/1" library_version="1">
+<description>&lt;B&gt;MKS4&lt;/B&gt;, 27 x 8 mm, grid 22.5 mm</description>
+<wire x1="-12.827" y1="4.318" x2="12.827" y2="4.318" width="0.1524" layer="21"/>
+<wire x1="13.335" y1="3.81" x2="13.335" y2="-3.81" width="0.1524" layer="21"/>
+<wire x1="12.827" y1="-4.318" x2="-12.827" y2="-4.318" width="0.1524" layer="21"/>
+<wire x1="-13.335" y1="-3.81" x2="-13.335" y2="3.81" width="0.1524" layer="21"/>
+<wire x1="-6.731" y1="1.905" x2="-6.731" y2="0" width="0.4064" layer="21"/>
+<wire x1="-6.731" y1="0" x2="-6.731" y2="-1.905" width="0.4064" layer="21"/>
+<wire x1="-7.62" y1="1.905" x2="-7.62" y2="0" width="0.4064" layer="21"/>
+<wire x1="-7.62" y1="0" x2="-7.62" y2="-1.905" width="0.4064" layer="21"/>
+<wire x1="12.827" y1="4.318" x2="13.335" y2="3.81" width="0.1524" layer="21" curve="-90"/>
+<wire x1="12.827" y1="-4.318" x2="13.335" y2="-3.81" width="0.1524" layer="21" curve="90"/>
+<wire x1="-13.335" y1="-3.81" x2="-12.827" y2="-4.318" width="0.1524" layer="21" curve="90"/>
+<wire x1="-13.335" y1="3.81" x2="-12.827" y2="4.318" width="0.1524" layer="21" curve="-90"/>
+<wire x1="-9.652" y1="0" x2="-7.62" y2="0" width="0.1524" layer="21"/>
+<wire x1="-6.731" y1="0" x2="9.652" y2="0" width="0.1524" layer="21"/>
+<pad name="1" x="-11.303" y="0" drill="1.016" diameter="2.54" shape="octagon"/>
+<pad name="2" x="11.303" y="0" drill="1.016" diameter="2.54" shape="octagon"/>
+<text x="-11.303" y="4.572" size="1.778" layer="25" ratio="10">&gt;NAME</text>
+<text x="-5.08" y="-2.54" size="1.778" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="C27.5B11" urn="urn:adsk.eagle:footprint:5370/1" library_version="1">
+<description>&lt;B&gt;MKS4&lt;/B&gt;, 31.6 x 11 mm, grid 27.5 mm</description>
+<wire x1="-15.24" y1="5.588" x2="15.24" y2="5.588" width="0.1524" layer="21"/>
+<wire x1="15.748" y1="5.08" x2="15.748" y2="-5.08" width="0.1524" layer="21"/>
+<wire x1="15.24" y1="-5.588" x2="-15.24" y2="-5.588" width="0.1524" layer="21"/>
+<wire x1="-15.748" y1="-5.08" x2="-15.748" y2="5.08" width="0.1524" layer="21"/>
+<wire x1="-6.731" y1="1.905" x2="-6.731" y2="0" width="0.4064" layer="21"/>
+<wire x1="-6.731" y1="0" x2="-6.731" y2="-1.905" width="0.4064" layer="21"/>
+<wire x1="-7.62" y1="1.905" x2="-7.62" y2="0" width="0.4064" layer="21"/>
+<wire x1="-7.62" y1="0" x2="-7.62" y2="-1.905" width="0.4064" layer="21"/>
+<wire x1="15.24" y1="5.588" x2="15.748" y2="5.08" width="0.1524" layer="21" curve="-90"/>
+<wire x1="15.24" y1="-5.588" x2="15.748" y2="-5.08" width="0.1524" layer="21" curve="90"/>
+<wire x1="-15.748" y1="-5.08" x2="-15.24" y2="-5.588" width="0.1524" layer="21" curve="90"/>
+<wire x1="-15.748" y1="5.08" x2="-15.24" y2="5.588" width="0.1524" layer="21" curve="-90"/>
+<wire x1="-11.557" y1="0" x2="-7.62" y2="0" width="0.1524" layer="21"/>
+<wire x1="-6.731" y1="0" x2="11.557" y2="0" width="0.1524" layer="21"/>
+<pad name="1" x="-13.716" y="0" drill="1.1938" diameter="3.1496" shape="octagon"/>
+<pad name="2" x="13.716" y="0" drill="1.1938" diameter="3.1496" shape="octagon"/>
+<text x="-13.716" y="5.842" size="1.778" layer="25" ratio="10">&gt;NAME</text>
+<text x="-5.08" y="-2.54" size="1.778" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="C27.5B13" urn="urn:adsk.eagle:footprint:5371/1" library_version="1">
+<description>&lt;B&gt;MKS4&lt;/B&gt;, 31.6 x 13 mm, grid 27.5 mm</description>
+<wire x1="-15.24" y1="6.604" x2="15.24" y2="6.604" width="0.1524" layer="21"/>
+<wire x1="15.748" y1="6.096" x2="15.748" y2="-6.096" width="0.1524" layer="21"/>
+<wire x1="15.24" y1="-6.604" x2="-15.24" y2="-6.604" width="0.1524" layer="21"/>
+<wire x1="-15.748" y1="-6.096" x2="-15.748" y2="6.096" width="0.1524" layer="21"/>
+<wire x1="-6.731" y1="1.905" x2="-6.731" y2="0" width="0.4064" layer="21"/>
+<wire x1="-6.731" y1="0" x2="-6.731" y2="-1.905" width="0.4064" layer="21"/>
+<wire x1="-7.62" y1="1.905" x2="-7.62" y2="0" width="0.4064" layer="21"/>
+<wire x1="-7.62" y1="0" x2="-7.62" y2="-1.905" width="0.4064" layer="21"/>
+<wire x1="15.24" y1="6.604" x2="15.748" y2="6.096" width="0.1524" layer="21" curve="-90"/>
+<wire x1="15.24" y1="-6.604" x2="15.748" y2="-6.096" width="0.1524" layer="21" curve="90"/>
+<wire x1="-15.748" y1="-6.096" x2="-15.24" y2="-6.604" width="0.1524" layer="21" curve="90"/>
+<wire x1="-15.748" y1="6.096" x2="-15.24" y2="6.604" width="0.1524" layer="21" curve="-90"/>
+<wire x1="-11.557" y1="0" x2="-7.62" y2="0" width="0.1524" layer="21"/>
+<wire x1="-6.731" y1="0" x2="11.557" y2="0" width="0.1524" layer="21"/>
+<pad name="1" x="-13.716" y="0" drill="1.1938" diameter="3.1496" shape="octagon"/>
+<pad name="2" x="13.716" y="0" drill="1.1938" diameter="3.1496" shape="octagon"/>
+<text x="-13.716" y="6.858" size="1.778" layer="25" ratio="10">&gt;NAME</text>
+<text x="-5.08" y="-2.54" size="1.778" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="C27.5B15" urn="urn:adsk.eagle:footprint:5372/1" library_version="1">
+<description>&lt;B&gt;MKS4&lt;/B&gt;, 31.6 x 15 mm, grid 27.5 mm</description>
+<wire x1="-15.24" y1="7.62" x2="15.24" y2="7.62" width="0.1524" layer="21"/>
+<wire x1="15.748" y1="7.112" x2="15.748" y2="-7.112" width="0.1524" layer="21"/>
+<wire x1="15.24" y1="-7.62" x2="-15.24" y2="-7.62" width="0.1524" layer="21"/>
+<wire x1="-15.748" y1="-7.112" x2="-15.748" y2="7.112" width="0.1524" layer="21"/>
+<wire x1="-6.731" y1="1.905" x2="-6.731" y2="0" width="0.4064" layer="21"/>
+<wire x1="-6.731" y1="0" x2="-6.731" y2="-1.905" width="0.4064" layer="21"/>
+<wire x1="-7.62" y1="1.905" x2="-7.62" y2="0" width="0.4064" layer="21"/>
+<wire x1="-7.62" y1="0" x2="-7.62" y2="-1.905" width="0.4064" layer="21"/>
+<wire x1="15.24" y1="7.62" x2="15.748" y2="7.112" width="0.1524" layer="21" curve="-90"/>
+<wire x1="15.24" y1="-7.62" x2="15.748" y2="-7.112" width="0.1524" layer="21" curve="90"/>
+<wire x1="-15.748" y1="-7.112" x2="-15.24" y2="-7.62" width="0.1524" layer="21" curve="90"/>
+<wire x1="-15.748" y1="7.112" x2="-15.24" y2="7.62" width="0.1524" layer="21" curve="-90"/>
+<wire x1="-11.557" y1="0" x2="-7.62" y2="0" width="0.1524" layer="21"/>
+<wire x1="-6.731" y1="0" x2="11.557" y2="0" width="0.1524" layer="21"/>
+<pad name="1" x="-13.716" y="0" drill="1.1938" diameter="3.1496" shape="octagon"/>
+<pad name="2" x="13.716" y="0" drill="1.1938" diameter="3.1496" shape="octagon"/>
+<text x="-13.716" y="7.874" size="1.778" layer="25" ratio="10">&gt;NAME</text>
+<text x="-5.08" y="-2.54" size="1.778" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="C27.5B17" urn="urn:adsk.eagle:footprint:5373/1" library_version="1">
+<description>&lt;B&gt;MKS4&lt;/B&gt;, 31.6 x 17 mm, grid 27.5 mm</description>
+<wire x1="-15.24" y1="8.509" x2="15.24" y2="8.509" width="0.1524" layer="21"/>
+<wire x1="15.748" y1="8.001" x2="15.748" y2="-8.001" width="0.1524" layer="21"/>
+<wire x1="15.24" y1="-8.509" x2="-15.24" y2="-8.509" width="0.1524" layer="21"/>
+<wire x1="-15.748" y1="-8.001" x2="-15.748" y2="8.001" width="0.1524" layer="21"/>
+<wire x1="-6.731" y1="1.905" x2="-6.731" y2="0" width="0.4064" layer="21"/>
+<wire x1="-6.731" y1="0" x2="-6.731" y2="-1.905" width="0.4064" layer="21"/>
+<wire x1="-7.62" y1="1.905" x2="-7.62" y2="0" width="0.4064" layer="21"/>
+<wire x1="-7.62" y1="0" x2="-7.62" y2="-1.905" width="0.4064" layer="21"/>
+<wire x1="15.24" y1="8.509" x2="15.748" y2="8.001" width="0.1524" layer="21" curve="-90"/>
+<wire x1="15.24" y1="-8.509" x2="15.748" y2="-8.001" width="0.1524" layer="21" curve="90"/>
+<wire x1="-15.748" y1="-8.001" x2="-15.24" y2="-8.509" width="0.1524" layer="21" curve="90"/>
+<wire x1="-15.748" y1="8.001" x2="-15.24" y2="8.509" width="0.1524" layer="21" curve="-90"/>
+<wire x1="-11.557" y1="0" x2="-7.62" y2="0" width="0.1524" layer="21"/>
+<wire x1="-6.731" y1="0" x2="11.557" y2="0" width="0.1524" layer="21"/>
+<pad name="1" x="-13.716" y="0" drill="1.1938" diameter="3.1496" shape="octagon"/>
+<pad name="2" x="13.716" y="0" drill="1.1938" diameter="3.1496" shape="octagon"/>
+<text x="-13.716" y="8.763" size="1.778" layer="25" ratio="10">&gt;NAME</text>
+<text x="-5.08" y="-2.54" size="1.778" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="C27.5B20" urn="urn:adsk.eagle:footprint:5374/1" library_version="1">
+<description>&lt;B&gt;MKS4&lt;/B&gt;, 31.6 x 20 mm, grid 27.5 mm</description>
+<wire x1="-15.24" y1="10.16" x2="15.24" y2="10.16" width="0.1524" layer="21"/>
+<wire x1="15.748" y1="9.652" x2="15.748" y2="-9.652" width="0.1524" layer="21"/>
+<wire x1="15.24" y1="-10.16" x2="-15.24" y2="-10.16" width="0.1524" layer="21"/>
+<wire x1="-15.748" y1="-9.652" x2="-15.748" y2="9.652" width="0.1524" layer="21"/>
+<wire x1="-6.731" y1="1.905" x2="-6.731" y2="0" width="0.4064" layer="21"/>
+<wire x1="-6.731" y1="0" x2="-6.731" y2="-1.905" width="0.4064" layer="21"/>
+<wire x1="-7.62" y1="1.905" x2="-7.62" y2="0" width="0.4064" layer="21"/>
+<wire x1="-7.62" y1="0" x2="-7.62" y2="-1.905" width="0.4064" layer="21"/>
+<wire x1="15.24" y1="10.16" x2="15.748" y2="9.652" width="0.1524" layer="21" curve="-90"/>
+<wire x1="15.24" y1="-10.16" x2="15.748" y2="-9.652" width="0.1524" layer="21" curve="90"/>
+<wire x1="-15.748" y1="-9.652" x2="-15.24" y2="-10.16" width="0.1524" layer="21" curve="90"/>
+<wire x1="-15.748" y1="9.652" x2="-15.24" y2="10.16" width="0.1524" layer="21" curve="-90"/>
+<wire x1="-11.557" y1="0" x2="-7.62" y2="0" width="0.1524" layer="21"/>
+<wire x1="-6.731" y1="0" x2="11.557" y2="0" width="0.1524" layer="21"/>
+<pad name="1" x="-13.716" y="0" drill="1.1938" diameter="3.1496" shape="octagon"/>
+<pad name="2" x="13.716" y="0" drill="1.1938" diameter="3.1496" shape="octagon"/>
+<text x="-13.589" y="10.414" size="1.778" layer="25" ratio="10">&gt;NAME</text>
+<text x="-5.08" y="-4.318" size="1.778" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="C27.5B9" urn="urn:adsk.eagle:footprint:5375/1" library_version="1">
+<description>&lt;B&gt;MKS4&lt;/B&gt;, 31.6 x 9 mm, grid 27.5 mm</description>
+<wire x1="-15.24" y1="4.572" x2="15.24" y2="4.572" width="0.1524" layer="21"/>
+<wire x1="15.748" y1="4.064" x2="15.748" y2="-4.064" width="0.1524" layer="21"/>
+<wire x1="15.24" y1="-4.572" x2="-15.24" y2="-4.572" width="0.1524" layer="21"/>
+<wire x1="-15.748" y1="-4.064" x2="-15.748" y2="4.064" width="0.1524" layer="21"/>
+<wire x1="-6.731" y1="1.905" x2="-6.731" y2="0" width="0.4064" layer="21"/>
+<wire x1="-6.731" y1="0" x2="-6.731" y2="-1.905" width="0.4064" layer="21"/>
+<wire x1="-7.62" y1="1.905" x2="-7.62" y2="0" width="0.4064" layer="21"/>
+<wire x1="-7.62" y1="0" x2="-7.62" y2="-1.905" width="0.4064" layer="21"/>
+<wire x1="15.24" y1="4.572" x2="15.748" y2="4.064" width="0.1524" layer="21" curve="-90"/>
+<wire x1="15.24" y1="-4.572" x2="15.748" y2="-4.064" width="0.1524" layer="21" curve="90"/>
+<wire x1="-15.748" y1="-4.064" x2="-15.24" y2="-4.572" width="0.1524" layer="21" curve="90"/>
+<wire x1="-15.748" y1="4.064" x2="-15.24" y2="4.572" width="0.1524" layer="21" curve="-90"/>
+<wire x1="-11.557" y1="0" x2="-7.62" y2="0" width="0.1524" layer="21"/>
+<wire x1="-6.731" y1="0" x2="11.557" y2="0" width="0.1524" layer="21"/>
+<pad name="1" x="-13.716" y="0" drill="1.1938" diameter="3.1496" shape="octagon"/>
+<pad name="2" x="13.716" y="0" drill="1.1938" diameter="3.1496" shape="octagon"/>
+<text x="-13.589" y="4.826" size="1.778" layer="25" ratio="10">&gt;NAME</text>
+<text x="-5.08" y="-2.54" size="1.778" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="C37.5B15" urn="urn:adsk.eagle:footprint:5376/1" library_version="1">
+<description>&lt;B&gt;MKP4&lt;/B&gt;, 42 x 15 mm, grid 37.5 mm</description>
+<wire x1="-20.32" y1="7.62" x2="20.32" y2="7.62" width="0.1524" layer="21"/>
+<wire x1="20.828" y1="7.112" x2="20.828" y2="-7.112" width="0.1524" layer="21"/>
+<wire x1="20.32" y1="-7.62" x2="-20.32" y2="-7.62" width="0.1524" layer="21"/>
+<wire x1="-20.828" y1="-7.112" x2="-20.828" y2="7.112" width="0.1524" layer="21"/>
+<wire x1="-6.731" y1="1.905" x2="-6.731" y2="0" width="0.4064" layer="21"/>
+<wire x1="-6.731" y1="0" x2="-6.731" y2="-1.905" width="0.4064" layer="21"/>
+<wire x1="-7.62" y1="1.905" x2="-7.62" y2="0" width="0.4064" layer="21"/>
+<wire x1="-7.62" y1="0" x2="-7.62" y2="-1.905" width="0.4064" layer="21"/>
+<wire x1="20.32" y1="7.62" x2="20.828" y2="7.112" width="0.1524" layer="21" curve="-90"/>
+<wire x1="20.32" y1="-7.62" x2="20.828" y2="-7.112" width="0.1524" layer="21" curve="90"/>
+<wire x1="-20.828" y1="-7.112" x2="-20.32" y2="-7.62" width="0.1524" layer="21" curve="90"/>
+<wire x1="-20.828" y1="7.112" x2="-20.32" y2="7.62" width="0.1524" layer="21" curve="-90"/>
+<wire x1="-16.002" y1="0" x2="-7.62" y2="0" width="0.1524" layer="21"/>
+<wire x1="-6.731" y1="0" x2="16.002" y2="0" width="0.1524" layer="21"/>
+<pad name="1" x="-18.796" y="0" drill="1.3208" diameter="3.1496" shape="octagon"/>
+<pad name="2" x="18.796" y="0" drill="1.3208" diameter="3.1496" shape="octagon"/>
+<text x="-18.796" y="7.874" size="1.778" layer="25" ratio="10">&gt;NAME</text>
+<text x="-5.08" y="-2.54" size="1.778" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="C37.5B19" urn="urn:adsk.eagle:footprint:5377/1" library_version="1">
+<description>&lt;B&gt;MKP4&lt;/B&gt;, 42 x 19 mm, grid 37.5 mm</description>
+<wire x1="-20.32" y1="8.509" x2="20.32" y2="8.509" width="0.1524" layer="21"/>
+<wire x1="20.828" y1="8.001" x2="20.828" y2="-8.001" width="0.1524" layer="21"/>
+<wire x1="20.32" y1="-8.509" x2="-20.32" y2="-8.509" width="0.1524" layer="21"/>
+<wire x1="-20.828" y1="-8.001" x2="-20.828" y2="8.001" width="0.1524" layer="21"/>
+<wire x1="-6.731" y1="1.905" x2="-6.731" y2="0" width="0.4064" layer="21"/>
+<wire x1="-6.731" y1="0" x2="-6.731" y2="-1.905" width="0.4064" layer="21"/>
+<wire x1="-7.62" y1="1.905" x2="-7.62" y2="0" width="0.4064" layer="21"/>
+<wire x1="-7.62" y1="0" x2="-7.62" y2="-1.905" width="0.4064" layer="21"/>
+<wire x1="20.32" y1="8.509" x2="20.828" y2="8.001" width="0.1524" layer="21" curve="-90"/>
+<wire x1="20.32" y1="-8.509" x2="20.828" y2="-8.001" width="0.1524" layer="21" curve="90"/>
+<wire x1="-20.828" y1="-8.001" x2="-20.32" y2="-8.509" width="0.1524" layer="21" curve="90"/>
+<wire x1="-20.828" y1="8.001" x2="-20.32" y2="8.509" width="0.1524" layer="21" curve="-90"/>
+<wire x1="-16.002" y1="0" x2="-7.62" y2="0" width="0.1524" layer="21"/>
+<wire x1="-6.731" y1="0" x2="16.002" y2="0" width="0.1524" layer="21"/>
+<pad name="1" x="-18.796" y="0" drill="1.3208" diameter="3.1496" shape="octagon"/>
+<pad name="2" x="18.796" y="0" drill="1.3208" diameter="3.1496" shape="octagon"/>
+<text x="-18.796" y="8.89" size="1.778" layer="25" ratio="10">&gt;NAME</text>
+<text x="-5.08" y="-2.54" size="1.778" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="C37.5B20" urn="urn:adsk.eagle:footprint:5378/1" library_version="1">
+<description>&lt;B&gt;MKP4&lt;/B&gt;, 42 x 20 mm, grid 37.5 mm</description>
+<wire x1="-20.32" y1="10.16" x2="20.32" y2="10.16" width="0.1524" layer="21"/>
+<wire x1="20.828" y1="9.652" x2="20.828" y2="-9.652" width="0.1524" layer="21"/>
+<wire x1="20.32" y1="-10.16" x2="-20.32" y2="-10.16" width="0.1524" layer="21"/>
+<wire x1="-20.828" y1="-9.652" x2="-20.828" y2="9.652" width="0.1524" layer="21"/>
+<wire x1="-6.731" y1="1.905" x2="-6.731" y2="0" width="0.4064" layer="21"/>
+<wire x1="-6.731" y1="0" x2="-6.731" y2="-1.905" width="0.4064" layer="21"/>
+<wire x1="-7.62" y1="1.905" x2="-7.62" y2="0" width="0.4064" layer="21"/>
+<wire x1="-7.62" y1="0" x2="-7.62" y2="-1.905" width="0.4064" layer="21"/>
+<wire x1="20.32" y1="10.16" x2="20.828" y2="9.652" width="0.1524" layer="21" curve="-90"/>
+<wire x1="20.32" y1="-10.16" x2="20.828" y2="-9.652" width="0.1524" layer="21" curve="90"/>
+<wire x1="-20.828" y1="-9.652" x2="-20.32" y2="-10.16" width="0.1524" layer="21" curve="90"/>
+<wire x1="-20.828" y1="9.652" x2="-20.32" y2="10.16" width="0.1524" layer="21" curve="-90"/>
+<wire x1="-16.002" y1="0" x2="-7.62" y2="0" width="0.1524" layer="21"/>
+<wire x1="-6.731" y1="0" x2="16.002" y2="0" width="0.1524" layer="21"/>
+<pad name="1" x="-18.796" y="0" drill="1.3208" diameter="3.1496" shape="octagon"/>
+<pad name="2" x="18.796" y="0" drill="1.3208" diameter="3.1496" shape="octagon"/>
+<text x="-18.796" y="10.414" size="1.778" layer="25" ratio="10">&gt;NAME</text>
+<text x="-5.08" y="-2.54" size="1.778" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="C5B2.5" urn="urn:adsk.eagle:footprint:5379/1" library_version="1">
+<description>&lt;B&gt;MKS2&lt;/B&gt;, 7.5 x 2.5 mm, grid 5.08 mm</description>
+<wire x1="-0.3048" y1="0.635" x2="-0.3048" y2="0" width="0.3048" layer="21"/>
+<wire x1="-0.3048" y1="0" x2="-0.3048" y2="-0.635" width="0.3048" layer="21"/>
+<wire x1="-0.3048" y1="0" x2="-1.524" y2="0" width="0.1524" layer="21"/>
+<wire x1="0.3302" y1="0.635" x2="0.3302" y2="0" width="0.3048" layer="21"/>
+<wire x1="0.3302" y1="0" x2="0.3302" y2="-0.635" width="0.3048" layer="21"/>
+<wire x1="0.3302" y1="0" x2="1.524" y2="0" width="0.1524" layer="21"/>
+<wire x1="-3.683" y1="1.016" x2="-3.683" y2="-1.016" width="0.1524" layer="21"/>
+<wire x1="-3.429" y1="-1.27" x2="3.429" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="3.683" y1="-1.016" x2="3.683" y2="1.016" width="0.1524" layer="21"/>
+<wire x1="3.429" y1="1.27" x2="-3.429" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="3.429" y1="1.27" x2="3.683" y2="1.016" width="0.1524" layer="21" curve="-90"/>
+<wire x1="3.429" y1="-1.27" x2="3.683" y2="-1.016" width="0.1524" layer="21" curve="90"/>
+<wire x1="-3.683" y1="-1.016" x2="-3.429" y2="-1.27" width="0.1524" layer="21" curve="90"/>
+<wire x1="-3.683" y1="1.016" x2="-3.429" y2="1.27" width="0.1524" layer="21" curve="-90"/>
+<pad name="1" x="-2.54" y="0" drill="0.8128" diameter="1.6002" shape="octagon"/>
+<pad name="2" x="2.54" y="0" drill="0.8128" diameter="1.6002" shape="octagon"/>
+<text x="-2.032" y="1.524" size="1.27" layer="25" ratio="10">&gt;NAME</text>
+<text x="-2.032" y="-2.794" size="1.27" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="C5B3.5" urn="urn:adsk.eagle:footprint:5381/1" library_version="1">
+<description>&lt;B&gt;MKS2&lt;/B&gt;, 7.5 x 4 mm, grid 5.08 mm</description>
+<wire x1="-0.3048" y1="0.635" x2="-0.3048" y2="0" width="0.3048" layer="21"/>
+<wire x1="-0.3048" y1="0" x2="-0.3048" y2="-0.635" width="0.3048" layer="21"/>
+<wire x1="-0.3048" y1="0" x2="-1.524" y2="0" width="0.1524" layer="21"/>
+<wire x1="0.3302" y1="0.635" x2="0.3302" y2="0" width="0.3048" layer="21"/>
+<wire x1="0.3302" y1="0" x2="0.3302" y2="-0.635" width="0.3048" layer="21"/>
+<wire x1="0.3302" y1="0" x2="1.524" y2="0" width="0.1524" layer="21"/>
+<wire x1="-3.683" y1="1.524" x2="-3.683" y2="-1.524" width="0.1524" layer="21"/>
+<wire x1="-3.429" y1="-1.778" x2="3.429" y2="-1.778" width="0.1524" layer="21"/>
+<wire x1="3.683" y1="-1.524" x2="3.683" y2="1.524" width="0.1524" layer="21"/>
+<wire x1="3.429" y1="1.778" x2="-3.429" y2="1.778" width="0.1524" layer="21"/>
+<wire x1="3.429" y1="1.778" x2="3.683" y2="1.524" width="0.1524" layer="21" curve="-90"/>
+<wire x1="3.429" y1="-1.778" x2="3.683" y2="-1.524" width="0.1524" layer="21" curve="90"/>
+<wire x1="-3.683" y1="-1.524" x2="-3.429" y2="-1.778" width="0.1524" layer="21" curve="90"/>
+<wire x1="-3.683" y1="1.524" x2="-3.429" y2="1.778" width="0.1524" layer="21" curve="-90"/>
+<pad name="1" x="-2.54" y="0" drill="0.8128" diameter="1.6002" shape="octagon"/>
+<pad name="2" x="2.54" y="0" drill="0.8128" diameter="1.6002" shape="octagon"/>
+<text x="-2.54" y="2.032" size="1.27" layer="25" ratio="10">&gt;NAME</text>
+<text x="-2.54" y="-3.302" size="1.27" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="C5B4.5" urn="urn:adsk.eagle:footprint:5382/1" library_version="1">
+<description>&lt;B&gt;MKS2&lt;/B&gt;, 7.5 x 4.5 mm, grid 5.08 mm</description>
+<wire x1="-0.3048" y1="0.635" x2="-0.3048" y2="0" width="0.3048" layer="21"/>
+<wire x1="-0.3048" y1="0" x2="-0.3048" y2="-0.635" width="0.3048" layer="21"/>
+<wire x1="-0.3048" y1="0" x2="-1.524" y2="0" width="0.1524" layer="21"/>
+<wire x1="0.3302" y1="0.635" x2="0.3302" y2="0" width="0.3048" layer="21"/>
+<wire x1="0.3302" y1="0" x2="0.3302" y2="-0.635" width="0.3048" layer="21"/>
+<wire x1="0.3302" y1="0" x2="1.524" y2="0" width="0.1524" layer="21"/>
+<wire x1="-3.683" y1="2.032" x2="-3.683" y2="-2.032" width="0.1524" layer="21"/>
+<wire x1="-3.429" y1="-2.286" x2="3.429" y2="-2.286" width="0.1524" layer="21"/>
+<wire x1="3.683" y1="-2.032" x2="3.683" y2="2.032" width="0.1524" layer="21"/>
+<wire x1="3.429" y1="2.286" x2="-3.429" y2="2.286" width="0.1524" layer="21"/>
+<wire x1="3.429" y1="2.286" x2="3.683" y2="2.032" width="0.1524" layer="21" curve="-90"/>
+<wire x1="3.429" y1="-2.286" x2="3.683" y2="-2.032" width="0.1524" layer="21" curve="90"/>
+<wire x1="-3.683" y1="-2.032" x2="-3.429" y2="-2.286" width="0.1524" layer="21" curve="90"/>
+<wire x1="-3.683" y1="2.032" x2="-3.429" y2="2.286" width="0.1524" layer="21" curve="-90"/>
+<pad name="1" x="-2.54" y="0" drill="0.8128" diameter="1.6002" shape="octagon"/>
+<pad name="2" x="2.54" y="0" drill="0.8128" diameter="1.6002" shape="octagon"/>
+<text x="-2.54" y="2.54" size="1.27" layer="25" ratio="10">&gt;NAME</text>
+<text x="-2.54" y="-3.81" size="1.27" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="C5B5" urn="urn:adsk.eagle:footprint:5383/1" library_version="1">
+<description>&lt;B&gt;MKS2&lt;/B&gt;, 7.5 x 5 mm, grid 5.08 mm</description>
+<wire x1="-0.3048" y1="0.635" x2="-0.3048" y2="0" width="0.3048" layer="21"/>
+<wire x1="-0.3048" y1="0" x2="-0.3048" y2="-0.635" width="0.3048" layer="21"/>
+<wire x1="-0.3048" y1="0" x2="-1.524" y2="0" width="0.1524" layer="21"/>
+<wire x1="0.3302" y1="0.635" x2="0.3302" y2="0" width="0.3048" layer="21"/>
+<wire x1="0.3302" y1="0" x2="0.3302" y2="-0.635" width="0.3048" layer="21"/>
+<wire x1="0.3302" y1="0" x2="1.524" y2="0" width="0.1524" layer="21"/>
+<wire x1="-3.683" y1="2.286" x2="-3.683" y2="-2.286" width="0.1524" layer="21"/>
+<wire x1="-3.429" y1="-2.54" x2="3.429" y2="-2.54" width="0.1524" layer="21"/>
+<wire x1="3.683" y1="-2.286" x2="3.683" y2="2.286" width="0.1524" layer="21"/>
+<wire x1="3.429" y1="2.54" x2="-3.429" y2="2.54" width="0.1524" layer="21"/>
+<wire x1="3.429" y1="2.54" x2="3.683" y2="2.286" width="0.1524" layer="21" curve="-90"/>
+<wire x1="3.429" y1="-2.54" x2="3.683" y2="-2.286" width="0.1524" layer="21" curve="90"/>
+<wire x1="-3.683" y1="-2.286" x2="-3.429" y2="-2.54" width="0.1524" layer="21" curve="90"/>
+<wire x1="-3.683" y1="2.286" x2="-3.429" y2="2.54" width="0.1524" layer="21" curve="-90"/>
+<pad name="1" x="-2.54" y="0" drill="0.8128" diameter="1.6002" shape="octagon"/>
+<pad name="2" x="2.54" y="0" drill="0.8128" diameter="1.6002" shape="octagon"/>
+<text x="-2.54" y="2.794" size="1.27" layer="25" ratio="10">&gt;NAME</text>
+<text x="-2.54" y="-2.286" size="1.27" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="C5B5.5" urn="urn:adsk.eagle:footprint:5384/1" library_version="1">
+<description>&lt;B&gt;MKS2&lt;/B&gt;, 7.5 x 5.5 mm, grid 5.08 mm</description>
+<wire x1="-0.3048" y1="0.635" x2="-0.3048" y2="0" width="0.3048" layer="21"/>
+<wire x1="-0.3048" y1="0" x2="-0.3048" y2="-0.635" width="0.3048" layer="21"/>
+<wire x1="-0.3048" y1="0" x2="-1.524" y2="0" width="0.1524" layer="21"/>
+<wire x1="0.3302" y1="0.635" x2="0.3302" y2="0" width="0.3048" layer="21"/>
+<wire x1="0.3302" y1="0" x2="0.3302" y2="-0.635" width="0.3048" layer="21"/>
+<wire x1="0.3302" y1="0" x2="1.524" y2="0" width="0.1524" layer="21"/>
+<wire x1="-3.683" y1="2.54" x2="-3.683" y2="-2.54" width="0.1524" layer="21"/>
+<wire x1="-3.429" y1="-2.794" x2="3.429" y2="-2.794" width="0.1524" layer="21"/>
+<wire x1="3.683" y1="-2.54" x2="3.683" y2="2.54" width="0.1524" layer="21"/>
+<wire x1="3.429" y1="2.794" x2="-3.429" y2="2.794" width="0.1524" layer="21"/>
+<wire x1="3.429" y1="2.794" x2="3.683" y2="2.54" width="0.1524" layer="21" curve="-90"/>
+<wire x1="3.429" y1="-2.794" x2="3.683" y2="-2.54" width="0.1524" layer="21" curve="90"/>
+<wire x1="-3.683" y1="-2.54" x2="-3.429" y2="-2.794" width="0.1524" layer="21" curve="90"/>
+<wire x1="-3.683" y1="2.54" x2="-3.429" y2="2.794" width="0.1524" layer="21" curve="-90"/>
+<pad name="1" x="-2.54" y="0" drill="0.8128" diameter="1.6002" shape="octagon"/>
+<pad name="2" x="2.54" y="0" drill="0.8128" diameter="1.6002" shape="octagon"/>
+<text x="-2.54" y="3.048" size="1.27" layer="25" ratio="10">&gt;NAME</text>
+<text x="-2.54" y="-2.286" size="1.27" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="C5B7.2" urn="urn:adsk.eagle:footprint:5385/1" library_version="1">
+<description>&lt;B&gt;MKS2&lt;/B&gt;, 7.5 x 7.2 mm, grid 5.08 mm</description>
+<wire x1="-1.524" y1="0" x2="-0.4572" y2="0" width="0.1524" layer="21"/>
+<wire x1="-0.4572" y1="0" x2="-0.4572" y2="0.762" width="0.4064" layer="21"/>
+<wire x1="-0.4572" y1="0" x2="-0.4572" y2="-0.762" width="0.4064" layer="21"/>
+<wire x1="0.4318" y1="0.762" x2="0.4318" y2="0" width="0.4064" layer="21"/>
+<wire x1="0.4318" y1="0" x2="1.524" y2="0" width="0.1524" layer="21"/>
+<wire x1="0.4318" y1="0" x2="0.4318" y2="-0.762" width="0.4064" layer="21"/>
+<wire x1="-3.683" y1="3.429" x2="-3.683" y2="-3.429" width="0.1524" layer="21"/>
+<wire x1="-3.429" y1="-3.683" x2="3.429" y2="-3.683" width="0.1524" layer="21"/>
+<wire x1="3.683" y1="-3.429" x2="3.683" y2="3.429" width="0.1524" layer="21"/>
+<wire x1="3.429" y1="3.683" x2="-3.429" y2="3.683" width="0.1524" layer="21"/>
+<wire x1="3.429" y1="3.683" x2="3.683" y2="3.429" width="0.1524" layer="21" curve="-90"/>
+<wire x1="3.429" y1="-3.683" x2="3.683" y2="-3.429" width="0.1524" layer="21" curve="90"/>
+<wire x1="-3.683" y1="-3.429" x2="-3.429" y2="-3.683" width="0.1524" layer="21" curve="90"/>
+<wire x1="-3.683" y1="3.429" x2="-3.429" y2="3.683" width="0.1524" layer="21" curve="-90"/>
+<pad name="1" x="-2.54" y="0" drill="0.8128" diameter="1.6002" shape="octagon"/>
+<pad name="2" x="2.54" y="0" drill="0.8128" diameter="1.6002" shape="octagon"/>
+<text x="-2.54" y="4.064" size="1.27" layer="25" ratio="10">&gt;NAME</text>
+<text x="-3.175" y="-2.921" size="1.27" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="C7.5B3" urn="urn:adsk.eagle:footprint:5386/1" library_version="1">
+<description>&lt;B&gt;MKS3&lt;/B&gt;, 10 x 3 mm, grid 7.62 mm</description>
+<wire x1="4.826" y1="1.524" x2="-4.826" y2="1.524" width="0.1524" layer="21"/>
+<wire x1="-5.08" y1="1.27" x2="-5.08" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="-4.826" y1="-1.524" x2="4.826" y2="-1.524" width="0.1524" layer="21"/>
+<wire x1="5.08" y1="-1.27" x2="5.08" y2="1.27" width="0.1524" layer="21"/>
+<wire x1="4.826" y1="1.524" x2="5.08" y2="1.27" width="0.1524" layer="21" curve="-90"/>
+<wire x1="4.826" y1="-1.524" x2="5.08" y2="-1.27" width="0.1524" layer="21" curve="90"/>
+<wire x1="-5.08" y1="-1.27" x2="-4.826" y2="-1.524" width="0.1524" layer="21" curve="90"/>
+<wire x1="-5.08" y1="1.27" x2="-4.826" y2="1.524" width="0.1524" layer="21" curve="-90"/>
+<wire x1="0.508" y1="0" x2="2.54" y2="0" width="0.1524" layer="21"/>
+<wire x1="-2.54" y1="0" x2="-0.508" y2="0" width="0.1524" layer="21"/>
+<wire x1="-0.508" y1="0.889" x2="-0.508" y2="0" width="0.4064" layer="21"/>
+<wire x1="-0.508" y1="0" x2="-0.508" y2="-0.889" width="0.4064" layer="21"/>
+<wire x1="0.508" y1="0.889" x2="0.508" y2="0" width="0.4064" layer="21"/>
+<wire x1="0.508" y1="0" x2="0.508" y2="-0.889" width="0.4064" layer="21"/>
+<pad name="1" x="-3.81" y="0" drill="0.9144" diameter="1.905" shape="octagon"/>
+<pad name="2" x="3.81" y="0" drill="0.9144" diameter="1.905" shape="octagon"/>
+<text x="-3.81" y="1.778" size="1.27" layer="25" ratio="10">&gt;NAME</text>
+<text x="-3.81" y="-3.048" size="1.27" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="C7.5B4" urn="urn:adsk.eagle:footprint:5387/1" library_version="1">
+<description>&lt;B&gt;MKS3&lt;/B&gt;, 10 x 4 mm, grid 7.62 mm</description>
+<wire x1="4.826" y1="2.032" x2="-4.826" y2="2.032" width="0.1524" layer="21"/>
+<wire x1="-5.08" y1="1.778" x2="-5.08" y2="-1.778" width="0.1524" layer="21"/>
+<wire x1="-4.826" y1="-2.032" x2="4.826" y2="-2.032" width="0.1524" layer="21"/>
+<wire x1="5.08" y1="-1.778" x2="5.08" y2="1.778" width="0.1524" layer="21"/>
+<wire x1="4.826" y1="2.032" x2="5.08" y2="1.778" width="0.1524" layer="21" curve="-90"/>
+<wire x1="4.826" y1="-2.032" x2="5.08" y2="-1.778" width="0.1524" layer="21" curve="90"/>
+<wire x1="-5.08" y1="-1.778" x2="-4.826" y2="-2.032" width="0.1524" layer="21" curve="90"/>
+<wire x1="-5.08" y1="1.778" x2="-4.826" y2="2.032" width="0.1524" layer="21" curve="-90"/>
+<wire x1="-1.27" y1="0" x2="2.667" y2="0" width="0.1524" layer="21"/>
+<wire x1="-2.667" y1="0" x2="-2.159" y2="0" width="0.1524" layer="21"/>
+<wire x1="-2.159" y1="1.27" x2="-2.159" y2="0" width="0.4064" layer="21"/>
+<wire x1="-2.159" y1="0" x2="-2.159" y2="-1.27" width="0.4064" layer="21"/>
+<wire x1="-1.27" y1="1.27" x2="-1.27" y2="0" width="0.4064" layer="21"/>
+<wire x1="-1.27" y1="0" x2="-1.27" y2="-1.27" width="0.4064" layer="21"/>
+<pad name="1" x="-3.81" y="0" drill="0.9144" diameter="1.905" shape="octagon"/>
+<pad name="2" x="3.81" y="0" drill="0.9144" diameter="1.905" shape="octagon"/>
+<text x="-3.81" y="2.286" size="1.27" layer="25" ratio="10">&gt;NAME</text>
+<text x="-3.81" y="-3.556" size="1.27" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="C7.5B5" urn="urn:adsk.eagle:footprint:5388/1" library_version="1">
+<description>&lt;B&gt;MKS3&lt;/B&gt;, 10 x 5 mm, grid 7.62 mm</description>
+<wire x1="4.953" y1="2.54" x2="-4.953" y2="2.54" width="0.1524" layer="21"/>
+<wire x1="-5.207" y1="2.286" x2="-5.207" y2="-2.286" width="0.1524" layer="21"/>
+<wire x1="-4.953" y1="-2.54" x2="4.953" y2="-2.54" width="0.1524" layer="21"/>
+<wire x1="5.207" y1="-2.286" x2="5.207" y2="2.286" width="0.1524" layer="21"/>
+<wire x1="4.953" y1="2.54" x2="5.207" y2="2.286" width="0.1524" layer="21" curve="-90"/>
+<wire x1="4.953" y1="-2.54" x2="5.207" y2="-2.286" width="0.1524" layer="21" curve="90"/>
+<wire x1="-5.207" y1="-2.286" x2="-4.953" y2="-2.54" width="0.1524" layer="21" curve="90"/>
+<wire x1="-5.207" y1="2.286" x2="-4.953" y2="2.54" width="0.1524" layer="21" curve="-90"/>
+<wire x1="-1.27" y1="0" x2="2.667" y2="0" width="0.1524" layer="21"/>
+<wire x1="-2.667" y1="0" x2="-2.159" y2="0" width="0.1524" layer="21"/>
+<wire x1="-2.159" y1="1.27" x2="-2.159" y2="0" width="0.4064" layer="21"/>
+<wire x1="-2.159" y1="0" x2="-2.159" y2="-1.27" width="0.4064" layer="21"/>
+<wire x1="-1.27" y1="1.27" x2="-1.27" y2="0" width="0.4064" layer="21"/>
+<wire x1="-1.27" y1="0" x2="-1.27" y2="-1.27" width="0.4064" layer="21"/>
+<pad name="1" x="-3.81" y="0" drill="0.9144" diameter="1.905" shape="octagon"/>
+<pad name="2" x="3.81" y="0" drill="0.9144" diameter="1.905" shape="octagon"/>
+<text x="-3.81" y="2.794" size="1.27" layer="25" ratio="10">&gt;NAME</text>
+<text x="-3.81" y="-4.064" size="1.27" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="C7.5B6" urn="urn:adsk.eagle:footprint:5389/1" library_version="1">
+<description>&lt;B&gt;MKS3&lt;/B&gt;, 10 x 6 mm, grid 7.62 mm</description>
+<wire x1="4.953" y1="3.048" x2="-4.953" y2="3.048" width="0.1524" layer="21"/>
+<wire x1="-5.207" y1="2.794" x2="-5.207" y2="-2.794" width="0.1524" layer="21"/>
+<wire x1="-4.953" y1="-3.048" x2="4.953" y2="-3.048" width="0.1524" layer="21"/>
+<wire x1="5.207" y1="-2.794" x2="5.207" y2="2.794" width="0.1524" layer="21"/>
+<wire x1="4.953" y1="3.048" x2="5.207" y2="2.794" width="0.1524" layer="21" curve="-90"/>
+<wire x1="4.953" y1="-3.048" x2="5.207" y2="-2.794" width="0.1524" layer="21" curve="90"/>
+<wire x1="-5.207" y1="-2.794" x2="-4.953" y2="-3.048" width="0.1524" layer="21" curve="90"/>
+<wire x1="-5.207" y1="2.794" x2="-4.953" y2="3.048" width="0.1524" layer="21" curve="-90"/>
+<wire x1="-1.27" y1="0" x2="2.667" y2="0" width="0.1524" layer="21"/>
+<wire x1="-2.667" y1="0" x2="-2.159" y2="0" width="0.1524" layer="21"/>
+<wire x1="-2.159" y1="1.27" x2="-2.159" y2="0" width="0.4064" layer="21"/>
+<wire x1="-2.159" y1="0" x2="-2.159" y2="-1.27" width="0.4064" layer="21"/>
+<wire x1="-1.27" y1="1.27" x2="-1.27" y2="0" width="0.4064" layer="21"/>
+<wire x1="-1.27" y1="0" x2="-1.27" y2="-1.27" width="0.4064" layer="21"/>
+<pad name="1" x="-3.81" y="0" drill="0.9144" diameter="1.905" shape="octagon"/>
+<pad name="2" x="3.81" y="0" drill="0.9144" diameter="1.905" shape="octagon"/>
+<text x="-3.683" y="3.302" size="1.27" layer="25" ratio="10">&gt;NAME</text>
+<text x="-0.889" y="-2.667" size="1.27" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+<package name="C2.5-3" urn="urn:adsk.eagle:footprint:5390/1" library_version="1">
+<description>&lt;B&gt;MKS2&lt;/B&gt;, 5 x 3 mm, grid 2.54 mm</description>
+<wire x1="-2.159" y1="1.524" x2="2.159" y2="1.524" width="0.1524" layer="21"/>
+<wire x1="2.159" y1="-1.524" x2="-2.159" y2="-1.524" width="0.1524" layer="21"/>
+<wire x1="2.413" y1="1.27" x2="2.413" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="-2.413" y1="1.27" x2="-2.413" y2="-1.27" width="0.1524" layer="21"/>
+<wire x1="2.159" y1="1.524" x2="2.413" y2="1.27" width="0.1524" layer="21" curve="-90"/>
+<wire x1="-2.413" y1="1.27" x2="-2.159" y2="1.524" width="0.1524" layer="21" curve="-90"/>
+<wire x1="2.159" y1="-1.524" x2="2.413" y2="-1.27" width="0.1524" layer="21" curve="90"/>
+<wire x1="-2.413" y1="-1.27" x2="-2.159" y2="-1.524" width="0.1524" layer="21" curve="90"/>
+<wire x1="1.27" y1="0" x2="0.381" y2="0" width="0.1524" layer="51"/>
+<wire x1="0.381" y1="0" x2="0.254" y2="0" width="0.1524" layer="21"/>
+<wire x1="0.254" y1="0" x2="0.254" y2="0.762" width="0.254" layer="21"/>
+<wire x1="0.254" y1="0" x2="0.254" y2="-0.762" width="0.254" layer="21"/>
+<wire x1="-0.254" y1="0.762" x2="-0.254" y2="0" width="0.254" layer="21"/>
+<wire x1="-0.254" y1="0" x2="-0.254" y2="-0.762" width="0.254" layer="21"/>
+<wire x1="-0.254" y1="0" x2="-0.381" y2="0" width="0.1524" layer="21"/>
+<wire x1="-0.381" y1="0" x2="-1.27" y2="0" width="0.1524" layer="51"/>
+<pad name="1" x="-1.27" y="0" drill="0.8128" diameter="1.6002" shape="octagon"/>
+<pad name="2" x="1.27" y="0" drill="0.8128" diameter="1.6002" shape="octagon"/>
+<text x="-1.651" y="1.778" size="1.27" layer="25" ratio="10">&gt;NAME</text>
+<text x="-1.651" y="-3.048" size="1.27" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+</packages>
+<packages3d>
+<package3d name="C5B3" urn="urn:adsk.eagle:package:5433/1" type="box" library_version="1">
+<description>MKS2, 7.5 x 3 mm, grid 5.08 mm</description>
+<packageinstances>
+<packageinstance name="C5B3"/>
+</packageinstances>
+</package3d>
+<package3d name="C10B4" urn="urn:adsk.eagle:package:5400/1" type="box" library_version="1">
+<description>MKS4, 13.4 x 4 mm, grid 10.16 mm</description>
+<packageinstances>
+<packageinstance name="C10B4"/>
+</packageinstances>
+</package3d>
+<package3d name="C10B5" urn="urn:adsk.eagle:package:5399/1" type="box" library_version="1">
+<description>MKS4, 13.4 x 5 mm, grid 10.16 mm</description>
+<packageinstances>
+<packageinstance name="C10B5"/>
+</packageinstances>
+</package3d>
+<package3d name="C10B6" urn="urn:adsk.eagle:package:5401/1" type="box" library_version="1">
+<description>MKS4, 13.4 x 6 mm, grid 10.16 mm</description>
+<packageinstances>
+<packageinstance name="C10B6"/>
+</packageinstances>
+</package3d>
+<package3d name="C15B5" urn="urn:adsk.eagle:package:5402/1" type="box" library_version="1">
+<description>MKS4, 18 x 5 mm, grid 15 mm</description>
+<packageinstances>
+<packageinstance name="C15B5"/>
+</packageinstances>
+</package3d>
+<package3d name="C15B6" urn="urn:adsk.eagle:package:5403/1" type="box" library_version="1">
+<description>MKS4, 18 x 6 mm, grid 15 mm</description>
+<packageinstances>
+<packageinstance name="C15B6"/>
+</packageinstances>
+</package3d>
+<package3d name="C15B7" urn="urn:adsk.eagle:package:5404/1" type="box" library_version="1">
+<description>MKS4, 18 x 7 mm, grid 15 mm</description>
+<packageinstances>
+<packageinstance name="C15B7"/>
+</packageinstances>
+</package3d>
+<package3d name="C15B8" urn="urn:adsk.eagle:package:5409/1" type="box" library_version="1">
+<description>MKS4, 18 x 8 mm, grid 15 mm</description>
+<packageinstances>
+<packageinstance name="C15B8"/>
+</packageinstances>
+</package3d>
+<package3d name="C15B9" urn="urn:adsk.eagle:package:5405/1" type="box" library_version="1">
+<description>MKS4, 18 x 9 mm, grid 15 mm</description>
+<packageinstances>
+<packageinstance name="C15B9"/>
+</packageinstances>
+</package3d>
+<package3d name="C2.5-2" urn="urn:adsk.eagle:package:5415/1" type="box" library_version="1">
+<description>MKS2, 5 x 2.5 mm, grid 2.54 mm</description>
+<packageinstances>
+<packageinstance name="C2.5-2"/>
+</packageinstances>
+</package3d>
+<package3d name="C2.5-4" urn="urn:adsk.eagle:package:5408/1" type="box" library_version="1">
+<description>MKS2, 5 x 4 mm, grid 2.54 mm</description>
+<packageinstances>
+<packageinstance name="C2.5-4"/>
+</packageinstances>
+</package3d>
+<package3d name="C2.5-5" urn="urn:adsk.eagle:package:5407/1" type="box" library_version="1">
+<description>MKS2, 5 x 5 mm, grid 2.54 mm</description>
+<packageinstances>
+<packageinstance name="C2.5-5"/>
+</packageinstances>
+</package3d>
+<package3d name="C2.5-6" urn="urn:adsk.eagle:package:5406/1" type="box" library_version="1">
+<description>MKS2, 5 x 6 mm, grid 2.54 mm</description>
+<packageinstances>
+<packageinstance name="C2.5-6"/>
+</packageinstances>
+</package3d>
+<package3d name="C22.5B10" urn="urn:adsk.eagle:package:5411/1" type="box" library_version="1">
+<description>MKS4, 27 x 10 mm, grid 22.5 mm</description>
+<packageinstances>
+<packageinstance name="C22.5B10"/>
+</packageinstances>
+</package3d>
+<package3d name="C22.5B11" urn="urn:adsk.eagle:package:5412/1" type="box" library_version="1">
+<description>MKS4, 27 x 11 mm, grid 22.5 mm</description>
+<packageinstances>
+<packageinstance name="C22.5B11"/>
+</packageinstances>
+</package3d>
+<package3d name="C22.5B6" urn="urn:adsk.eagle:package:5410/1" type="box" library_version="1">
+<description>MKS4, 27 x 6 mm, grid 22.5 mm</description>
+<packageinstances>
+<packageinstance name="C22.5B6"/>
+</packageinstances>
+</package3d>
+<package3d name="C22.5B7" urn="urn:adsk.eagle:package:5414/1" type="box" library_version="1">
+<description>MKS4, 27 x 7 mm, grid 22.5 mm</description>
+<packageinstances>
+<packageinstance name="C22.5B7"/>
+</packageinstances>
+</package3d>
+<package3d name="C22.5B8" urn="urn:adsk.eagle:package:5413/1" type="box" library_version="1">
+<description>MKS4, 27 x 8 mm, grid 22.5 mm</description>
+<packageinstances>
+<packageinstance name="C22.5B8"/>
+</packageinstances>
+</package3d>
+<package3d name="C27.5B11" urn="urn:adsk.eagle:package:5416/1" type="box" library_version="1">
+<description>MKS4, 31.6 x 11 mm, grid 27.5 mm</description>
+<packageinstances>
+<packageinstance name="C27.5B11"/>
+</packageinstances>
+</package3d>
+<package3d name="C27.5B13" urn="urn:adsk.eagle:package:5420/1" type="box" library_version="1">
+<description>MKS4, 31.6 x 13 mm, grid 27.5 mm</description>
+<packageinstances>
+<packageinstance name="C27.5B13"/>
+</packageinstances>
+</package3d>
+<package3d name="C27.5B15" urn="urn:adsk.eagle:package:5417/1" type="box" library_version="1">
+<description>MKS4, 31.6 x 15 mm, grid 27.5 mm</description>
+<packageinstances>
+<packageinstance name="C27.5B15"/>
+</packageinstances>
+</package3d>
+<package3d name="C27.5B17" urn="urn:adsk.eagle:package:5418/1" type="box" library_version="1">
+<description>MKS4, 31.6 x 17 mm, grid 27.5 mm</description>
+<packageinstances>
+<packageinstance name="C27.5B17"/>
+</packageinstances>
+</package3d>
+<package3d name="C27.5B20" urn="urn:adsk.eagle:package:5421/1" type="box" library_version="1">
+<description>MKS4, 31.6 x 20 mm, grid 27.5 mm</description>
+<packageinstances>
+<packageinstance name="C27.5B20"/>
+</packageinstances>
+</package3d>
+<package3d name="C27.5B9" urn="urn:adsk.eagle:package:5419/1" type="box" library_version="1">
+<description>MKS4, 31.6 x 9 mm, grid 27.5 mm</description>
+<packageinstances>
+<packageinstance name="C27.5B9"/>
+</packageinstances>
+</package3d>
+<package3d name="C37.5B15" urn="urn:adsk.eagle:package:5425/1" type="box" library_version="1">
+<description>MKP4, 42 x 15 mm, grid 37.5 mm</description>
+<packageinstances>
+<packageinstance name="C37.5B15"/>
+</packageinstances>
+</package3d>
+<package3d name="C37.5B19" urn="urn:adsk.eagle:package:5422/1" type="box" library_version="1">
+<description>MKP4, 42 x 19 mm, grid 37.5 mm</description>
+<packageinstances>
+<packageinstance name="C37.5B19"/>
+</packageinstances>
+</package3d>
+<package3d name="C37.5B20" urn="urn:adsk.eagle:package:5423/1" type="box" library_version="1">
+<description>MKP4, 42 x 20 mm, grid 37.5 mm</description>
+<packageinstances>
+<packageinstance name="C37.5B20"/>
+</packageinstances>
+</package3d>
+<package3d name="C5B2.5" urn="urn:adsk.eagle:package:5426/1" type="box" library_version="1">
+<description>MKS2, 7.5 x 2.5 mm, grid 5.08 mm</description>
+<packageinstances>
+<packageinstance name="C5B2.5"/>
+</packageinstances>
+</package3d>
+<package3d name="C5B3.5" urn="urn:adsk.eagle:package:5427/1" type="box" library_version="1">
+<description>MKS2, 7.5 x 4 mm, grid 5.08 mm</description>
+<packageinstances>
+<packageinstance name="C5B3.5"/>
+</packageinstances>
+</package3d>
+<package3d name="C5B4.5" urn="urn:adsk.eagle:package:5424/1" type="box" library_version="1">
+<description>MKS2, 7.5 x 4.5 mm, grid 5.08 mm</description>
+<packageinstances>
+<packageinstance name="C5B4.5"/>
+</packageinstances>
+</package3d>
+<package3d name="C5B5" urn="urn:adsk.eagle:package:5428/1" type="box" library_version="1">
+<description>MKS2, 7.5 x 5 mm, grid 5.08 mm</description>
+<packageinstances>
+<packageinstance name="C5B5"/>
+</packageinstances>
+</package3d>
+<package3d name="C5B5.5" urn="urn:adsk.eagle:package:5429/1" type="box" library_version="1">
+<description>MKS2, 7.5 x 5.5 mm, grid 5.08 mm</description>
+<packageinstances>
+<packageinstance name="C5B5.5"/>
+</packageinstances>
+</package3d>
+<package3d name="C5B7.2" urn="urn:adsk.eagle:package:5430/1" type="box" library_version="1">
+<description>MKS2, 7.5 x 7.2 mm, grid 5.08 mm</description>
+<packageinstances>
+<packageinstance name="C5B7.2"/>
+</packageinstances>
+</package3d>
+<package3d name="C7.5B3" urn="urn:adsk.eagle:package:5434/1" type="box" library_version="1">
+<description>MKS3, 10 x 3 mm, grid 7.62 mm</description>
+<packageinstances>
+<packageinstance name="C7.5B3"/>
+</packageinstances>
+</package3d>
+<package3d name="C7.5B4" urn="urn:adsk.eagle:package:5431/1" type="box" library_version="1">
+<description>MKS3, 10 x 4 mm, grid 7.62 mm</description>
+<packageinstances>
+<packageinstance name="C7.5B4"/>
+</packageinstances>
+</package3d>
+<package3d name="C7.5B5" urn="urn:adsk.eagle:package:5432/1" type="box" library_version="1">
+<description>MKS3, 10 x 5 mm, grid 7.62 mm</description>
+<packageinstances>
+<packageinstance name="C7.5B5"/>
+</packageinstances>
+</package3d>
+<package3d name="C7.5B6" urn="urn:adsk.eagle:package:5435/1" type="box" library_version="1">
+<description>MKS3, 10 x 6 mm, grid 7.62 mm</description>
+<packageinstances>
+<packageinstance name="C7.5B6"/>
+</packageinstances>
+</package3d>
+<package3d name="C2.5-3" urn="urn:adsk.eagle:package:5436/1" type="box" library_version="1">
+<description>MKS2, 5 x 3 mm, grid 2.54 mm</description>
+<packageinstances>
+<packageinstance name="C2.5-3"/>
+</packageinstances>
+</package3d>
+</packages3d>
+<symbols>
+<symbol name="C" urn="urn:adsk.eagle:symbol:5352/1" library_version="1">
+<wire x1="0" y1="-2.54" x2="0" y2="-2.032" width="0.1524" layer="94"/>
+<wire x1="0" y1="0" x2="0" y2="-0.508" width="0.1524" layer="94"/>
+<text x="1.524" y="0.381" size="1.778" layer="95">&gt;NAME</text>
+<text x="1.524" y="-4.699" size="1.778" layer="96">&gt;VALUE</text>
+<rectangle x1="-2.032" y1="-1.016" x2="2.032" y2="-0.508" layer="94"/>
+<rectangle x1="-2.032" y1="-2.032" x2="2.032" y2="-1.524" layer="94"/>
+<pin name="1" x="0" y="2.54" visible="off" length="short" direction="pas" swaplevel="1" rot="R270"/>
+<pin name="2" x="0" y="-5.08" visible="off" length="short" direction="pas" swaplevel="1" rot="R90"/>
+</symbol>
+</symbols>
+<devicesets>
+<deviceset name="C" urn="urn:adsk.eagle:component:5444/1" prefix="C" uservalue="yes" library_version="1">
+<description>&lt;B&gt;CAPACITOR&lt;/B&gt;&lt;p&gt;
+naming: grid - package width</description>
+<gates>
+<gate name="G$1" symbol="C" x="0" y="0"/>
+</gates>
+<devices>
+<device name="10/4" package="C10B4">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:5400/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="10/5" package="C10B5">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:5399/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="10/6" package="C10B6">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:5401/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="15/5" package="C15B5">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:5402/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="15/6" package="C15B6">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:5403/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="15/7" package="C15B7">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:5404/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="15/8" package="C15B8">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:5409/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="15/9" package="C15B9">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:5405/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="2.5/2" package="C2.5-2">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:5415/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="2.5/4" package="C2.5-4">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:5408/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="2.5/5" package="C2.5-5">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:5407/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="2.5/6" package="C2.5-6">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:5406/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="22/10" package="C22.5B10">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:5411/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="22/11" package="C22.5B11">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:5412/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="22/6" package="C22.5B6">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:5410/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="22/7" package="C22.5B7">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:5414/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="22/8" package="C22.5B8">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:5413/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="27/11" package="C27.5B11">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:5416/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="27/13" package="C27.5B13">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:5420/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="27/15" package="C27.5B15">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:5417/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="27/17" package="C27.5B17">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:5418/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="27/20" package="C27.5B20">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:5421/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="27/9" package="C27.5B9">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:5419/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="37/15" package="C37.5B15">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:5425/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="37/19" package="C37.5B19">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:5422/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="37/20" package="C37.5B20">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:5423/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="5/2.5" package="C5B2.5">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:5426/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="5/3" package="C5B3">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:5433/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="5/3.5" package="C5B3.5">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:5427/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="5/4.5" package="C5B4.5">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:5424/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="5/5" package="C5B5">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:5428/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="5/5.5" package="C5B5.5">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:5429/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="5/7.2" package="C5B7.2">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:5430/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="7.5/3" package="C7.5B3">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:5434/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="7.5/4" package="C7.5B4">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:5431/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="7.5/5" package="C7.5B5">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:5432/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="7.5/6" package="C7.5B6">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:5435/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+<device name="2,5-3" package="C2.5-3">
+<connects>
+<connect gate="G$1" pin="1" pad="1"/>
+<connect gate="G$1" pin="2" pad="2"/>
+</connects>
+<package3dinstances>
+<package3dinstance package3d_urn="urn:adsk.eagle:package:5436/1"/>
+</package3dinstances>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+</devicesets>
+</library>
+<library name="transistor-fet">
+<description>&lt;b&gt;Field Effect Transistors&lt;/b&gt;&lt;p&gt;
+&lt;author&gt;Created by librarian@cadsoft.de&lt;/author&gt;&lt;p&gt;
+&lt;p&gt;
+Symbols changed according to IEC617&lt;p&gt; 
+All types, packages and assignment to symbols and pins checked&lt;p&gt;
+Package outlines partly checked&lt;p&gt;
+&lt;p&gt;
+JFET = junction FET&lt;p&gt;
+IGBT-x = insulated gate bipolar transistor&lt;p&gt;
+x=N: NPN; x=P: PNP&lt;p&gt;
+IGFET-mc-nnn; (IGFET=insulated gate field effect transistor)&lt;P&gt;
+m=D: depletion mode (Verdr&amp;auml;ngungstyp)&lt;p&gt;
+m=E: enhancement mode (Anreicherungstyp)&lt;p&gt;
+c: N=N-channel; P=P-Channel&lt;p&gt;
+nnn=GDS:  gate, drain, source&lt;p&gt;
+2GDS: 2 x gate, drain, source&lt;p&gt;
+GnDS: gate, n x drain, source&lt;p&gt;
+GDSB: gate, drain, source, bulk&lt;p&gt;
+&lt;p&gt;
+by R. Vogg  15.March.2002</description>
+<packages>
+<package name="TO-92">
+<description>&lt;b&gt;&lt;/b&gt;</description>
+<wire x1="-2.1" y1="-1.6" x2="2.1" y2="-1.6" width="0.2032" layer="21"/>
+<wire x1="-2.1" y1="-1.6" x2="-1.4" y2="2.3" width="0.2032" layer="21" curve="-98.057233"/>
+<wire x1="2.1" y1="-1.6" x2="1.4" y2="2.3" width="0.2032" layer="21" curve="99.798366"/>
+<wire x1="-1.4" y1="2.3" x2="1.4" y2="2.3" width="0.2032" layer="51" curve="-63.781584"/>
+<pad name="3" x="1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="2" x="0" y="1.905" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<pad name="1" x="-1.27" y="0" drill="0.8128" diameter="1.6764" shape="octagon"/>
+<text x="3.175" y="0.635" size="1.016" layer="25" ratio="18">&gt;NAME</text>
+<text x="3.175" y="-1.27" size="0.8128" layer="27" ratio="10">&gt;VALUE</text>
+</package>
+</packages>
+<symbols>
+<symbol name="MFNS">
+<wire x1="-1.1176" y1="2.413" x2="-1.1176" y2="-2.54" width="0.254" layer="94"/>
+<wire x1="-1.1176" y1="-2.54" x2="-2.54" y2="-2.54" width="0.1524" layer="94"/>
+<wire x1="2.54" y1="1.905" x2="0.5334" y2="1.905" width="0.1524" layer="94"/>
+<wire x1="2.54" y1="0" x2="2.54" y2="-1.905" width="0.1524" layer="94"/>
+<wire x1="0.508" y1="-1.905" x2="2.54" y2="-1.905" width="0.1524" layer="94"/>
+<wire x1="2.54" y1="2.54" x2="2.54" y2="1.905" width="0.1524" layer="94"/>
+<wire x1="2.54" y1="1.905" x2="4.1275" y2="1.905" width="0.1524" layer="94"/>
+<wire x1="4.1275" y1="1.905" x2="4.1275" y2="0.762" width="0.1524" layer="94"/>
+<wire x1="4.1275" y1="-1.905" x2="2.54" y2="-1.905" width="0.1524" layer="94"/>
+<wire x1="2.54" y1="-1.905" x2="2.54" y2="-2.54" width="0.1524" layer="94"/>
+<wire x1="4.1275" y1="0.762" x2="3.5719" y2="-0.4763" width="0.1524" layer="94"/>
+<wire x1="3.5719" y1="-0.4763" x2="4.1275" y2="-0.4763" width="0.1524" layer="94"/>
+<wire x1="4.1275" y1="-0.4763" x2="4.6831" y2="-0.4763" width="0.1524" layer="94"/>
+<wire x1="4.6831" y1="-0.4763" x2="4.1275" y2="0.762" width="0.1524" layer="94"/>
+<wire x1="3.4925" y1="0.762" x2="4.1275" y2="0.762" width="0.1524" layer="94"/>
+<wire x1="4.1275" y1="0.762" x2="4.7625" y2="0.762" width="0.1524" layer="94"/>
+<wire x1="4.7625" y1="0.762" x2="5.0165" y2="1.016" width="0.1524" layer="94"/>
+<wire x1="3.4925" y1="0.762" x2="3.2385" y2="0.508" width="0.1524" layer="94"/>
+<wire x1="0.508" y1="0" x2="1.778" y2="-0.508" width="0.1524" layer="94"/>
+<wire x1="1.778" y1="-0.508" x2="1.778" y2="0.508" width="0.1524" layer="94"/>
+<wire x1="1.778" y1="0.508" x2="0.508" y2="0" width="0.1524" layer="94"/>
+<wire x1="1.651" y1="0" x2="2.54" y2="0" width="0.1524" layer="94"/>
+<wire x1="1.651" y1="0.254" x2="0.762" y2="0" width="0.3048" layer="94"/>
+<wire x1="0.762" y1="0" x2="1.651" y2="-0.254" width="0.3048" layer="94"/>
+<wire x1="1.651" y1="-0.254" x2="1.651" y2="0" width="0.3048" layer="94"/>
+<wire x1="1.651" y1="0" x2="1.397" y2="0" width="0.3048" layer="94"/>
+<wire x1="4.1275" y1="-0.4763" x2="4.1275" y2="-1.905" width="0.1524" layer="94"/>
+<circle x="2.54" y="-1.905" radius="0.127" width="0.4064" layer="94"/>
+<circle x="2.54" y="1.905" radius="0.127" width="0.4064" layer="94"/>
+<text x="6.35" y="0" size="1.778" layer="95">&gt;NAME</text>
+<text x="6.35" y="-2.54" size="1.778" layer="96">&gt;VALUE</text>
+<text x="1.27" y="2.54" size="1.016" layer="95">D</text>
+<text x="1.27" y="-3.175" size="1.016" layer="95">S</text>
+<text x="-2.54" y="-1.27" size="1.016" layer="95">G</text>
+<rectangle x1="-0.254" y1="-2.54" x2="0.508" y2="-1.27" layer="94"/>
+<rectangle x1="-0.254" y1="1.27" x2="0.508" y2="2.54" layer="94"/>
+<rectangle x1="-0.254" y1="-0.889" x2="0.508" y2="0.889" layer="94"/>
+<pin name="G" x="-2.54" y="-2.54" visible="off" length="point" direction="pas"/>
+<pin name="D" x="2.54" y="5.08" visible="off" length="short" direction="pas" rot="R270"/>
+<pin name="S" x="2.54" y="-5.08" visible="off" length="short" direction="pas" rot="R90"/>
+<polygon width="0.1524" layer="94">
+<vertex x="4.1275" y="0.635"/>
+<vertex x="3.6513" y="-0.3969"/>
+<vertex x="4.6038" y="-0.3969"/>
+</polygon>
+</symbol>
+</symbols>
+<devicesets>
+<deviceset name="2N7000" prefix="Q">
+<description>&lt;b&gt;N-Channel MOSFET&lt;/b&gt;</description>
+<gates>
+<gate name="G$1" symbol="MFNS" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="TO-92">
+<connects>
+<connect gate="G$1" pin="D" pad="3"/>
+<connect gate="G$1" pin="G" pad="2"/>
+<connect gate="G$1" pin="S" pad="1"/>
+</connects>
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+</devicesets>
+</library>
+</libraries>
+<attributes>
+</attributes>
+<variantdefs>
+</variantdefs>
+<classes>
+<class number="0" name="default" width="0.3048" drill="0">
+<clearance class="0" value="0.3048"/>
+</class>
+<class number="1" name="5v" width="0.4064" drill="0">
+<clearance class="1" value="0.4064"/>
+</class>
+<class number="2" name="3v" width="0.4064" drill="0">
+<clearance class="2" value="0.4064"/>
+</class>
+<class number="3" name="Gnd" width="0.4064" drill="0">
+<clearance class="3" value="0.4064"/>
+</class>
+</classes>
+<parts>
+<part name="U$1" library="1455413453956-wemos" deviceset="WEMOS" device=""/>
+<part name="X" library="con-wago-500" deviceset="W237-102" device="" value="PWR"/>
+<part name="J1" library="con-tycoelectronics" deviceset="RJ45" device="" technology="-8X"/>
+<part name="R1" library="SparkFun-Resistors" library_urn="urn:adsk.eagle:library:532" deviceset="10KOHM" device="-HORIZ-1/4W-1%" package3d_urn="urn:adsk.eagle:package:39658/1" value="10k"/>
+<part name="JP1" library="pinhead" deviceset="PINHD-1X2" device="" value="BZR"/>
+<part name="SV1" library="con-lstb" deviceset="MA04-1" device="" value="RELAY"/>
+<part name="SV2" library="con-lstb" deviceset="MA04-1" device="" value="LCD"/>
+<part name="R2" library="SparkFun-Resistors" library_urn="urn:adsk.eagle:library:532" deviceset="10KOHM" device="-HORIZ-1/4W-1%" package3d_urn="urn:adsk.eagle:package:39658/1" value="10k"/>
+<part name="R3" library="SparkFun-Resistors" library_urn="urn:adsk.eagle:library:532" deviceset="10KOHM" device="-HORIZ-1/4W-1%" package3d_urn="urn:adsk.eagle:package:39658/1" value="10k"/>
+<part name="R4" library="SparkFun-Resistors" library_urn="urn:adsk.eagle:library:532" deviceset="10KOHM" device="-HORIZ-1/4W-1%" package3d_urn="urn:adsk.eagle:package:39658/1" value="10k"/>
+<part name="R5" library="SparkFun-Resistors" library_urn="urn:adsk.eagle:library:532" deviceset="10KOHM" device="-HORIZ-1/4W-1%" package3d_urn="urn:adsk.eagle:package:39658/1" value="10k"/>
+<part name="C1" library="capacitor-wima" library_urn="urn:adsk.eagle:library:116" deviceset="C" device="5/3" package3d_urn="urn:adsk.eagle:package:5433/1" value="100uF"/>
+<part name="Q1" library="transistor-fet" deviceset="2N7000" device=""/>
+<part name="Q2" library="transistor-fet" deviceset="2N7000" device=""/>
+</parts>
+<sheets>
+<sheet>
+<plain>
+<text x="-7.62" y="63.5" size="1.778" layer="97">1 - GND
+2 - Cool (D5)
+3 - Heat (D0)
+4 - +5v</text>
+<text x="-7.62" y="35.56" size="1.778" layer="97">6 - Door (D7)
+5 - GND
+4 - OneWire (D6) 
+3 - 3v3</text>
+<text x="50.8" y="30.48" size="1.778" layer="97">1 - +5v
+2 - GND</text>
+<text x="119.38" y="22.86" size="1.778" layer="97">1 - Gnd
+2 - +5v
+3 - 5v SDA
+4 - 5v SCL</text>
+</plain>
+<instances>
+<instance part="U$1" gate="G$1" x="48.26" y="50.8" smashed="yes">
+<attribute name="NAME" x="48.26" y="74.422" size="1.27" layer="95"/>
+<attribute name="VALUE" x="48.26" y="48.26" size="1.778" layer="96"/>
+</instance>
+<instance part="X" gate="-1" x="63.5" y="33.02" smashed="yes" rot="R90">
+<attribute name="NAME" x="62.611" y="33.02" size="1.778" layer="95" rot="R270"/>
+</instance>
+<instance part="X" gate="-2" x="68.58" y="33.02" smashed="yes" rot="R90">
+<attribute name="VALUE" x="72.263" y="30.48" size="1.778" layer="96" rot="R90"/>
+<attribute name="NAME" x="67.691" y="33.02" size="1.778" layer="95" rot="R270"/>
+</instance>
+<instance part="J1" gate="G$1" x="20.32" y="40.64" smashed="yes" rot="R180">
+<attribute name="NAME" x="22.86" y="30.48" size="1.778" layer="95" rot="R180"/>
+<attribute name="VALUE" x="22.86" y="53.848" size="1.778" layer="96" rot="R180"/>
+</instance>
+<instance part="R1" gate="G$1" x="33.02" y="35.56" smashed="yes" rot="R90">
+<attribute name="NAME" x="31.5214" y="31.75" size="1.778" layer="95" rot="R90"/>
+<attribute name="VALUE" x="36.322" y="31.75" size="1.778" layer="96" rot="R90"/>
+</instance>
+<instance part="JP1" gate="G$1" x="48.26" y="83.82" smashed="yes">
+<attribute name="NAME" x="41.91" y="89.535" size="1.778" layer="95"/>
+<attribute name="VALUE" x="41.91" y="78.74" size="1.778" layer="96"/>
+</instance>
+<instance part="SV1" gate="1" x="15.24" y="73.66" smashed="yes">
+<attribute name="VALUE" x="13.97" y="63.5" size="1.778" layer="96"/>
+<attribute name="NAME" x="13.97" y="79.502" size="1.778" layer="95"/>
+</instance>
+<instance part="SV2" gate="1" x="116.84" y="25.4" smashed="yes" rot="R180">
+<attribute name="VALUE" x="118.11" y="35.56" size="1.778" layer="96" rot="R180"/>
+<attribute name="NAME" x="118.11" y="19.558" size="1.778" layer="95" rot="R180"/>
+</instance>
+<instance part="R2" gate="G$1" x="96.52" y="83.82" smashed="yes" rot="R270">
+<attribute name="NAME" x="98.0186" y="87.63" size="1.778" layer="95" rot="R270"/>
+<attribute name="VALUE" x="93.218" y="87.63" size="1.778" layer="96" rot="R270"/>
+</instance>
+<instance part="R3" gate="G$1" x="111.76" y="83.82" smashed="yes" rot="R270">
+<attribute name="NAME" x="113.2586" y="87.63" size="1.778" layer="95" rot="R270"/>
+<attribute name="VALUE" x="108.458" y="87.63" size="1.778" layer="96" rot="R270"/>
+</instance>
+<instance part="R4" gate="G$1" x="96.52" y="60.96" smashed="yes" rot="R270">
+<attribute name="NAME" x="98.0186" y="64.77" size="1.778" layer="95" rot="R270"/>
+<attribute name="VALUE" x="93.218" y="64.77" size="1.778" layer="96" rot="R270"/>
+</instance>
+<instance part="R5" gate="G$1" x="111.76" y="60.96" smashed="yes" rot="R270">
+<attribute name="NAME" x="113.2586" y="64.77" size="1.778" layer="95" rot="R270"/>
+<attribute name="VALUE" x="108.458" y="64.77" size="1.778" layer="96" rot="R270"/>
+</instance>
+<instance part="C1" gate="G$1" x="48.26" y="40.64" smashed="yes" rot="R270">
+<attribute name="NAME" x="48.641" y="39.116" size="1.778" layer="95" rot="R270"/>
+</instance>
+<instance part="Q1" gate="G$1" x="104.14" y="78.74" smashed="yes" rot="R270">
+<attribute name="NAME" x="111.76" y="80.01" size="1.778" layer="95" rot="R180"/>
+<attribute name="VALUE" x="99.06" y="69.85" size="1.778" layer="96"/>
+</instance>
+<instance part="Q2" gate="G$1" x="104.14" y="55.88" smashed="yes" rot="R270">
+<attribute name="NAME" x="111.76" y="57.15" size="1.778" layer="95" rot="R180"/>
+<attribute name="VALUE" x="99.06" y="46.99" size="1.778" layer="96"/>
+</instance>
+</instances>
+<busses>
+</busses>
+<nets>
+<net name="GND" class="3">
+<segment>
+<pinref part="U$1" gate="G$1" pin="GND"/>
+<wire x1="68.58" y1="55.88" x2="73.66" y2="55.88" width="0.1524" layer="91"/>
+<wire x1="73.66" y1="55.88" x2="73.66" y2="50.8" width="0.1524" layer="91"/>
+<wire x1="73.66" y1="50.8" x2="73.66" y2="43.18" width="0.1524" layer="91"/>
+<wire x1="73.66" y1="43.18" x2="68.58" y2="43.18" width="0.1524" layer="91"/>
+<pinref part="X" gate="-2" pin="KL"/>
+<wire x1="68.58" y1="38.1" x2="68.58" y2="43.18" width="0.1524" layer="91"/>
+<junction x="68.58" y="43.18"/>
+<wire x1="27.94" y1="43.18" x2="50.8" y2="43.18" width="0.1524" layer="91"/>
+<wire x1="50.8" y1="43.18" x2="68.58" y2="43.18" width="0.1524" layer="91"/>
+<wire x1="27.94" y1="43.18" x2="27.94" y2="68.58" width="0.1524" layer="91"/>
+<wire x1="27.94" y1="68.58" x2="27.94" y2="78.74" width="0.1524" layer="91"/>
+<wire x1="78.74" y1="50.8" x2="78.74" y2="45.72" width="0.1524" layer="91"/>
+<wire x1="78.74" y1="45.72" x2="93.98" y2="45.72" width="0.1524" layer="91"/>
+<wire x1="73.66" y1="50.8" x2="78.74" y2="50.8" width="0.1524" layer="91"/>
+<junction x="73.66" y="50.8"/>
+<wire x1="109.22" y1="30.48" x2="93.98" y2="30.48" width="0.1524" layer="91"/>
+<wire x1="93.98" y1="30.48" x2="93.98" y2="45.72" width="0.1524" layer="91"/>
+<label x="88.9" y="33.02" size="1.778" layer="95"/>
+<pinref part="JP1" gate="G$1" pin="2"/>
+<wire x1="45.72" y1="83.82" x2="38.1" y2="83.82" width="0.1524" layer="91"/>
+<wire x1="38.1" y1="83.82" x2="38.1" y2="78.74" width="0.1524" layer="91"/>
+<wire x1="38.1" y1="78.74" x2="27.94" y2="78.74" width="0.1524" layer="91"/>
+<pinref part="SV1" gate="1" pin="1"/>
+<wire x1="22.86" y1="68.58" x2="27.94" y2="68.58" width="0.1524" layer="91"/>
+<junction x="27.94" y="68.58"/>
+<pinref part="SV2" gate="1" pin="1"/>
+<pinref part="C1" gate="G$1" pin="1"/>
+<wire x1="50.8" y1="40.64" x2="50.8" y2="43.18" width="0.1524" layer="91"/>
+<junction x="50.8" y="43.18"/>
+<pinref part="J1" gate="G$1" pin="5"/>
+<wire x1="27.94" y1="43.18" x2="22.86" y2="43.18" width="0.1524" layer="91"/>
+<junction x="27.94" y="43.18"/>
+</segment>
+</net>
+<net name="5V" class="1">
+<segment>
+<pinref part="U$1" gate="G$1" pin="5V"/>
+<wire x1="68.58" y1="53.34" x2="71.12" y2="53.34" width="0.1524" layer="91"/>
+<wire x1="71.12" y1="53.34" x2="71.12" y2="48.26" width="0.1524" layer="91"/>
+<wire x1="71.12" y1="48.26" x2="63.5" y2="48.26" width="0.1524" layer="91"/>
+<pinref part="X" gate="-1" pin="KL"/>
+<wire x1="63.5" y1="38.1" x2="63.5" y2="48.26" width="0.1524" layer="91"/>
+<wire x1="63.5" y1="48.26" x2="43.18" y2="48.26" width="0.1524" layer="91"/>
+<junction x="63.5" y="48.26"/>
+<wire x1="43.18" y1="48.26" x2="35.56" y2="48.26" width="0.1524" layer="91"/>
+<wire x1="35.56" y1="48.26" x2="35.56" y2="58.42" width="0.1524" layer="91"/>
+<wire x1="25.4" y1="60.96" x2="30.48" y2="60.96" width="0.1524" layer="91"/>
+<wire x1="30.48" y1="60.96" x2="30.48" y2="58.42" width="0.1524" layer="91"/>
+<wire x1="30.48" y1="58.42" x2="35.56" y2="58.42" width="0.1524" layer="91"/>
+<wire x1="71.12" y1="48.26" x2="96.52" y2="48.26" width="0.1524" layer="91"/>
+<junction x="71.12" y="48.26"/>
+<wire x1="109.22" y1="27.94" x2="96.52" y2="27.94" width="0.1524" layer="91"/>
+<wire x1="96.52" y1="27.94" x2="96.52" y2="48.26" width="0.1524" layer="91"/>
+<label x="96.52" y="25.4" size="1.778" layer="95"/>
+<wire x1="25.4" y1="60.96" x2="25.4" y2="76.2" width="0.1524" layer="91"/>
+<pinref part="SV1" gate="1" pin="4"/>
+<wire x1="25.4" y1="76.2" x2="22.86" y2="76.2" width="0.1524" layer="91"/>
+<pinref part="SV2" gate="1" pin="2"/>
+<pinref part="C1" gate="G$1" pin="2"/>
+<wire x1="43.18" y1="40.64" x2="43.18" y2="48.26" width="0.1524" layer="91"/>
+<junction x="43.18" y="48.26"/>
+<pinref part="R3" gate="G$1" pin="1"/>
+<wire x1="111.76" y1="88.9" x2="111.76" y2="91.44" width="0.1524" layer="91"/>
+<wire x1="111.76" y1="91.44" x2="116.84" y2="91.44" width="0.1524" layer="91"/>
+<wire x1="116.84" y1="91.44" x2="116.84" y2="66.04" width="0.1524" layer="91"/>
+<pinref part="R5" gate="G$1" pin="1"/>
+<wire x1="116.84" y1="66.04" x2="111.76" y2="66.04" width="0.1524" layer="91"/>
+<wire x1="111.76" y1="91.44" x2="111.76" y2="93.98" width="0.1524" layer="91"/>
+<junction x="111.76" y="91.44"/>
+<wire x1="111.76" y1="93.98" x2="119.38" y2="93.98" width="0.1524" layer="91"/>
+<wire x1="119.38" y1="93.98" x2="119.38" y2="48.26" width="0.1524" layer="91"/>
+<wire x1="119.38" y1="48.26" x2="96.52" y2="48.26" width="0.1524" layer="91"/>
+<junction x="96.52" y="48.26"/>
+</segment>
+</net>
+<net name="3V3" class="2">
+<segment>
+<pinref part="U$1" gate="G$1" pin="3V3"/>
+<wire x1="43.18" y1="53.34" x2="40.64" y2="53.34" width="0.1524" layer="91"/>
+<wire x1="40.64" y1="53.34" x2="40.64" y2="30.48" width="0.1524" layer="91"/>
+<pinref part="R1" gate="G$1" pin="1"/>
+<wire x1="27.94" y1="38.1" x2="27.94" y2="30.48" width="0.1524" layer="91"/>
+<wire x1="27.94" y1="30.48" x2="33.02" y2="30.48" width="0.1524" layer="91"/>
+<wire x1="40.64" y1="30.48" x2="33.02" y2="30.48" width="0.1524" layer="91"/>
+<junction x="33.02" y="30.48"/>
+<wire x1="81.28" y1="25.4" x2="40.64" y2="25.4" width="0.1524" layer="91"/>
+<wire x1="40.64" y1="25.4" x2="40.64" y2="30.48" width="0.1524" layer="91"/>
+<junction x="40.64" y="30.48"/>
+<pinref part="J1" gate="G$1" pin="3"/>
+<wire x1="27.94" y1="38.1" x2="22.86" y2="38.1" width="0.1524" layer="91"/>
+<wire x1="81.28" y1="25.4" x2="81.28" y2="93.98" width="0.1524" layer="91"/>
+<wire x1="81.28" y1="93.98" x2="96.52" y2="93.98" width="0.1524" layer="91"/>
+<pinref part="R2" gate="G$1" pin="1"/>
+<wire x1="96.52" y1="88.9" x2="96.52" y2="91.44" width="0.1524" layer="91"/>
+<wire x1="96.52" y1="91.44" x2="91.44" y2="91.44" width="0.1524" layer="91"/>
+<wire x1="91.44" y1="91.44" x2="91.44" y2="66.04" width="0.1524" layer="91"/>
+<pinref part="R4" gate="G$1" pin="1"/>
+<wire x1="91.44" y1="66.04" x2="96.52" y2="66.04" width="0.1524" layer="91"/>
+<wire x1="96.52" y1="91.44" x2="101.6" y2="91.44" width="0.1524" layer="91"/>
+<junction x="96.52" y="91.44"/>
+<pinref part="Q1" gate="G$1" pin="G"/>
+<wire x1="101.6" y1="91.44" x2="101.6" y2="81.28" width="0.1524" layer="91"/>
+<wire x1="96.52" y1="66.04" x2="101.6" y2="66.04" width="0.1524" layer="91"/>
+<junction x="96.52" y="66.04"/>
+<pinref part="Q2" gate="G$1" pin="G"/>
+<wire x1="101.6" y1="66.04" x2="101.6" y2="58.42" width="0.1524" layer="91"/>
+<wire x1="96.52" y1="93.98" x2="96.52" y2="91.44" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="D6" class="0">
+<segment>
+<pinref part="R1" gate="G$1" pin="2"/>
+<pinref part="U$1" gate="G$1" pin="D6"/>
+<wire x1="43.18" y1="60.96" x2="33.02" y2="60.96" width="0.1524" layer="91"/>
+<wire x1="33.02" y1="60.96" x2="33.02" y2="40.64" width="0.1524" layer="91"/>
+<pinref part="J1" gate="G$1" pin="4"/>
+<wire x1="33.02" y1="40.64" x2="22.86" y2="40.64" width="0.1524" layer="91"/>
+<junction x="33.02" y="40.64"/>
+</segment>
+</net>
+<net name="D7" class="0">
+<segment>
+<wire x1="38.1" y1="45.72" x2="38.1" y2="58.42" width="0.1524" layer="91"/>
+<pinref part="U$1" gate="G$1" pin="D7"/>
+<wire x1="38.1" y1="58.42" x2="43.18" y2="58.42" width="0.1524" layer="91"/>
+<pinref part="J1" gate="G$1" pin="6"/>
+<wire x1="22.86" y1="45.72" x2="38.1" y2="45.72" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="N$6" class="0">
+<segment>
+<pinref part="U$1" gate="G$1" pin="D3"/>
+<wire x1="68.58" y1="60.96" x2="71.12" y2="60.96" width="0.1524" layer="91"/>
+<wire x1="71.12" y1="60.96" x2="71.12" y2="93.98" width="0.1524" layer="91"/>
+<wire x1="71.12" y1="93.98" x2="38.1" y2="93.98" width="0.1524" layer="91"/>
+<wire x1="38.1" y1="93.98" x2="38.1" y2="86.36" width="0.1524" layer="91"/>
+<wire x1="38.1" y1="86.36" x2="45.72" y2="86.36" width="0.1524" layer="91"/>
+<pinref part="JP1" gate="G$1" pin="1"/>
+<wire x1="48.26" y1="86.36" x2="45.72" y2="86.36" width="0.1524" layer="91"/>
+<junction x="45.72" y="86.36"/>
+</segment>
+</net>
+<net name="N$7" class="0">
+<segment>
+<pinref part="SV1" gate="1" pin="2"/>
+<wire x1="22.86" y1="71.12" x2="30.48" y2="71.12" width="0.1524" layer="91"/>
+<wire x1="30.48" y1="71.12" x2="30.48" y2="63.5" width="0.1524" layer="91"/>
+<pinref part="U$1" gate="G$1" pin="D5"/>
+<wire x1="30.48" y1="63.5" x2="43.18" y2="63.5" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="N$8" class="0">
+<segment>
+<pinref part="SV1" gate="1" pin="3"/>
+<wire x1="22.86" y1="73.66" x2="33.02" y2="73.66" width="0.1524" layer="91"/>
+<wire x1="33.02" y1="73.66" x2="33.02" y2="66.04" width="0.1524" layer="91"/>
+<pinref part="U$1" gate="G$1" pin="D0"/>
+<wire x1="33.02" y1="66.04" x2="43.18" y2="66.04" width="0.1524" layer="91"/>
+</segment>
+</net>
+<net name="SCL5V" class="0">
+<segment>
+<wire x1="127" y1="38.1" x2="104.14" y2="38.1" width="0.1524" layer="91"/>
+<pinref part="SV2" gate="1" pin="4"/>
+<wire x1="109.22" y1="22.86" x2="104.14" y2="22.86" width="0.1524" layer="91"/>
+<wire x1="104.14" y1="38.1" x2="104.14" y2="22.86" width="0.1524" layer="91"/>
+<wire x1="127" y1="38.1" x2="127" y2="76.2" width="0.1524" layer="91"/>
+<pinref part="R3" gate="G$1" pin="2"/>
+<wire x1="111.76" y1="78.74" x2="111.76" y2="76.2" width="0.1524" layer="91"/>
+<pinref part="Q1" gate="G$1" pin="D"/>
+<wire x1="111.76" y1="76.2" x2="109.22" y2="76.2" width="0.1524" layer="91"/>
+<wire x1="127" y1="76.2" x2="111.76" y2="76.2" width="0.1524" layer="91"/>
+<junction x="111.76" y="76.2"/>
+</segment>
+</net>
+<net name="5V_SDA" class="0">
+<segment>
+<wire x1="109.22" y1="25.4" x2="101.6" y2="25.4" width="0.1524" layer="91"/>
+<pinref part="SV2" gate="1" pin="3"/>
+<wire x1="101.6" y1="25.4" x2="101.6" y2="40.64" width="0.1524" layer="91"/>
+<wire x1="101.6" y1="40.64" x2="124.46" y2="40.64" width="0.1524" layer="91"/>
+<pinref part="R5" gate="G$1" pin="2"/>
+<wire x1="111.76" y1="55.88" x2="111.76" y2="53.34" width="0.1524" layer="91"/>
+<pinref part="Q2" gate="G$1" pin="D"/>
+<wire x1="111.76" y1="53.34" x2="109.22" y2="53.34" width="0.1524" layer="91"/>
+<wire x1="124.46" y1="40.64" x2="124.46" y2="53.34" width="0.1524" layer="91"/>
+<wire x1="124.46" y1="53.34" x2="111.76" y2="53.34" width="0.1524" layer="91"/>
+<junction x="111.76" y="53.34"/>
+</segment>
+</net>
+<net name="N$1" class="0">
+<segment>
+<pinref part="R4" gate="G$1" pin="2"/>
+<wire x1="96.52" y1="55.88" x2="96.52" y2="53.34" width="0.1524" layer="91"/>
+<pinref part="Q2" gate="G$1" pin="S"/>
+<wire x1="96.52" y1="53.34" x2="99.06" y2="53.34" width="0.1524" layer="91"/>
+<pinref part="U$1" gate="G$1" pin="D2"/>
+<wire x1="68.58" y1="63.5" x2="76.2" y2="63.5" width="0.1524" layer="91"/>
+<wire x1="76.2" y1="63.5" x2="76.2" y2="53.34" width="0.1524" layer="91"/>
+<wire x1="76.2" y1="53.34" x2="96.52" y2="53.34" width="0.1524" layer="91"/>
+<junction x="96.52" y="53.34"/>
+</segment>
+</net>
+<net name="N$5" class="0">
+<segment>
+<pinref part="R2" gate="G$1" pin="2"/>
+<pinref part="Q1" gate="G$1" pin="S"/>
+<wire x1="96.52" y1="78.74" x2="96.52" y2="76.2" width="0.1524" layer="91"/>
+<wire x1="96.52" y1="76.2" x2="99.06" y2="76.2" width="0.1524" layer="91"/>
+<wire x1="96.52" y1="76.2" x2="76.2" y2="76.2" width="0.1524" layer="91"/>
+<junction x="96.52" y="76.2"/>
+<wire x1="76.2" y1="76.2" x2="76.2" y2="66.04" width="0.1524" layer="91"/>
+<pinref part="U$1" gate="G$1" pin="D1"/>
+<wire x1="76.2" y1="66.04" x2="68.58" y2="66.04" width="0.1524" layer="91"/>
+</segment>
+</net>
+</nets>
+</sheet>
+</sheets>
+</schematic>
+</drawing>
+<compatibility>
+<note version="6.3" minversion="6.2.2" severity="warning">
+Since Version 6.2.2 text objects can contain more than one line,
+which will not be processed correctly with this version.
+</note>
+<note version="8.2" severity="warning">
+Since Version 8.2, EAGLE supports online libraries. The ids
+of those online libraries will not be understood (or retained)
+with this version.
+</note>
+<note version="8.3" severity="warning">
+Since Version 8.3, EAGLE supports URNs for individual library
+assets (packages, symbols, and devices). The URNs of those assets
+will not be understood (or retained) with this version.
+</note>
+<note version="8.3" severity="warning">
+Since Version 8.3, EAGLE supports the association of 3D packages
+with devices in libraries, schematics, and board files. Those 3D
+packages will not be understood (or retained) with this version.
+</note>
+</compatibility>
+</eagle>


### PR DESCRIPTION
Created a through-hole equivalent of your newest board.  No level-shifter sub-board needed.   Updated the .md as well but did not add links to the eagle files since I was not sure what the links would be.

Advantage here (aside from saving maybe a buck or two) is the board is the same size as the others so your original case, etc., will work.
