### PR TITLE
Fixed problem with strings not being printed on LCD display (only fir…

### DIFF
--- a/src/IicLcd.cpp
+++ b/src/IicLcd.cpp
@@ -275,7 +275,7 @@ inline size_t IIClcd::write(uint8_t value) {
 	if (!_bufferOnly) {
 		send(value, Rs);
 	}
-	return 0;
+	return 1;  
 }
 
 /************ low level data pushing commands **********/


### PR DESCRIPTION
Only the first char of a string is printed on the LCD. There is a change in the underlying Print::print.cpp class that requires a positive value to continue printing the string. 