### PR TITLE
Fix compiler warning

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -36,6 +36,7 @@ lib_deps =
     https://github.com/PaulStoffregen/XPT2046_Touchscreen
     Adafruit GFX Library
     Adafruit ILI9341
+    Adafruit BusIO
 upload_speed = ${common.upload_speed}
 monitor_speed = ${common.monitor_speed}
 upload_port = ${common.upload_port}

--- a/src/PiLink.cpp
+++ b/src/PiLink.cpp
@@ -144,7 +144,7 @@ void PiLink::print_P(const char *fmt, ... ){
  *
  * @param fmt - sprintf format string
  */
-void PiLink::print(char *fmt, ... ){
+void PiLink::print(const char *fmt, ... ){
 	va_list args;
 	va_start (args, fmt );
 	vsnprintf(printfBuff, PRINTF_BUFFER_SIZE, fmt, args);
@@ -430,7 +430,7 @@ void PiLink::receive(void){
 	inline bool changed(uint8_t &a, uint8_t b) { uint8_t c = a; a=b; return b!=c; }
 	inline bool changed(temperature &a, temperature b) { temperature c = a; a=b; return b!=c; }
 	inline bool changed(double &a, double b) { double c = a; a=b; return b!=c; }
-	inline bool changed(PChar &a, PChar b) { PChar c = a; a=b; return b!=c; }
+	inline bool changed(PChar &a, const char* b) { PChar c = a; a=(PChar)b; return b!=c; }
 #else
 	#define JSON_BEER_TEMP  "BeerTemp"
 	#define JSON_BEER_SET	"BeerSet"

--- a/src/PiLink.h
+++ b/src/PiLink.h
@@ -70,7 +70,7 @@ class PiLink{
 
 	static void receiveJson(void); // receive settings as JSON key:value pairs
 	
-	static void print(char *fmt, ...); // use when format string is stored in RAM
+	static void print(const char *fmt, ...); // use when format string is stored in RAM
 #ifdef ARDUINO
 	static void print(char c)       // inline for arduino
 #if !defined(ESP8266) && !defined(ESP32)


### PR DESCRIPTION
This PR has two commits.  The first fixes a rather noisy compiler warning:

```
warning: ISO C++ forbids converting a string constant to 'char*'
```

The second commit is unrelated, but was a small housekeeping change as well.  My system updated to PlatformIO 5 recently, and afterwards the ESP32 build failed because of a missing library.  This adds that library. (Note that I haven't tested the addition beyond getting a successful build, I don't have an ESP32 to test with.)