### PR TITLE
Add prometheus http endpoint

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -14,6 +14,7 @@ lib_deps =
     OneWire
     ArduinoJson@6.15.1
     bblanchon/StreamUtils @ ^1.5.0
+    ESP Async WebServer
 
 ; Let's also include some other common build flags for ease-of-use
 build_flags = !python3 scripts/gen_version.py
@@ -40,6 +41,7 @@ lib_deps =
     Adafruit GFX Library
     Adafruit ILI9341
     Adafruit BusIO
+    AsyncTCP
 upload_speed = ${common.upload_speed}
 monitor_speed = ${common.monitor_speed}
 upload_port = ${common.upload_port}

--- a/src/CommandProcessor.cpp
+++ b/src/CommandProcessor.cpp
@@ -23,6 +23,7 @@
 #include "Brewpi.h"
 #include "Display.h"
 #include "PiLink.h"
+#include "PromServer.h"
 #include "SettingLoader.h"
 #include "SettingsManager.h"
 #include "TempControl.h"
@@ -403,6 +404,11 @@ void CommandProcessor::setDeviceNames() {
   for (JsonPair kv : root) {
     DeviceNameManager::setDeviceName(kv.key().c_str(), kv.value().as<char *>());
   }
+
+  // The probe names are used in the prometheus output, so changing the
+  // name should invalidate the cache.
+  if (Config::Prometheus::enable())
+    promServer.invalidateCache();
 }
 
 /**

--- a/src/Config.h
+++ b/src/Config.h
@@ -387,6 +387,11 @@ namespace Config {
      * \brief Length to use for conversion buffers
      */
     constexpr auto bufferLen = 12;
+
+    /**
+     * \brief Maximum length of a temp string
+     */
+    constexpr auto maxLength = 9;
   };
 
   /**
@@ -397,4 +402,28 @@ namespace Config {
    * overwritten with 1.
    */
   constexpr bool forceDeviceDefaults = true;
+
+  /**
+   * \brief Prometheus configuration
+   */
+  namespace Prometheus {
+    /**
+     * \brief Enable Prometheus instrumentation support
+     *
+     * Only enabled when WiFi is enabled. The feature doesn't make sense when
+     * there is only serial.
+     *
+     * \see PromServer
+     */
+    constexpr bool enable() {
+      // Enable if wifi is enabled
+      return Config::PiLink::useWifi;
+    };
+
+    /**
+     * \brief TCP port to bind Prometheus HTTP service to
+     * \see PromServer
+     */
+    constexpr auto port = 8080;
+  };
 };

--- a/src/DeviceManager.h
+++ b/src/DeviceManager.h
@@ -28,6 +28,7 @@
 #include "OneWireDevices.h"
 #include "Pins.h"
 #include "EepromStructs.h"
+#include "Ticks.h"
 
 
 #ifdef ARDUINO

--- a/src/DeviceNameManager.cpp
+++ b/src/DeviceNameManager.cpp
@@ -27,9 +27,9 @@
 #include "DeviceNameManager.h"
 
 /**
- * Set a human readable name for a device.
- * @param device - The identifier for the device, most commonly the OneWire device address (in hex)
- * @param name - The name to set
+ * \brief Set a human readable name for a device.
+ * \param device - The identifier for the device, most commonly the OneWire device address (in hex)
+ * \param name - The name to set
  */
 void DeviceNameManager::setDeviceName(const char* device, const char* name)
 {
@@ -45,8 +45,11 @@ void DeviceNameManager::setDeviceName(const char* device, const char* name)
 
 
 /**
- * Get the human readable name for a device.
- * @param device - The identifier for the device, most commonly the OneWire device address (in hex)
+ * \brief Get the human readable name for a device.
+ *
+ * If no name has been registered, the device ID will be returned.
+ * \param device - The identifier for the device, most commonly the OneWire device address (in hex)
+ * \return The registered device name, or if none is set, the provided device ID
  */
 String DeviceNameManager::getDeviceName(const char* device) {
   char filename[32];
@@ -61,13 +64,13 @@ String DeviceNameManager::getDeviceName(const char* device) {
     }
   }
 
-  return "";
+  return device;
 }
 
 
 /**
- * Get the Filename that contains the device human name metadata for a given device.
- * @param device - The identifier for the device, most commonly the OneWire device address (in hex)
+ * \brief Get the Filename that contains the device human name metadata for a given device.
+ * \param device - The identifier for the device, most commonly the OneWire device address (in hex)
  */
 inline void DeviceNameManager::deviceNameFilename(char* filename, const char* device) {
   strcpy(filename, DeviceNameManager::filenamePrefix);
@@ -76,7 +79,7 @@ inline void DeviceNameManager::deviceNameFilename(char* filename, const char* de
 
 
 /**
- * Prefix used when building device name filenames
+ * \brief Prefix used when building device name filenames
  *
  * This helps disambiguate the name files from other data, and makes it easier
  * to produce a list of named probes.
@@ -84,7 +87,8 @@ inline void DeviceNameManager::deviceNameFilename(char* filename, const char* de
 const char DeviceNameManager::filenamePrefix[] = "/dn/";
 
 /**
- * Calculate length of filename prefix.
+ * \brief Calculate length of DeviceNameManager::filenamePrefix
+ *
  * This is done as a constexpr so it can be calculated at compile time
  */
 constexpr int DeviceNameManager::prefixLength() {
@@ -93,8 +97,8 @@ constexpr int DeviceNameManager::prefixLength() {
 
 
 /**
- * Delete a configured device name
- * @param device - The identifier for the device, most commonly the OneWire device address (in hex)
+ * \brief Delete a configured device name
+ * \param device - The identifier for the device, most commonly the OneWire device address (in hex)
  */
 void DeviceNameManager::deleteDeviceName(const char* device) {
   char filename[32];
@@ -106,7 +110,7 @@ void DeviceNameManager::deleteDeviceName(const char* device) {
 
 #if defined(ESP32)
 /**
- * Get list of configured device names
+ * \brief Get list of configured device names
  */
 void DeviceNameManager::enumerateDeviceNames(JsonDocument& doc) {
   File root = SPIFFS.open(filenamePrefix);
@@ -125,7 +129,7 @@ void DeviceNameManager::enumerateDeviceNames(JsonDocument& doc) {
 #else
 
 /**
- * Get list of configured device names
+ * \brief Get list of configured device names
  */
 void DeviceNameManager::enumerateDeviceNames(JsonDocument& doc) {
   Dir dir = SPIFFS.openDir(filenamePrefix);
@@ -139,9 +143,9 @@ void DeviceNameManager::enumerateDeviceNames(JsonDocument& doc) {
 
 
 /**
- * Given a filename, get a DeviceName
+ * \brief Given a filename, get a DeviceName
  *
- * @param filename
+ * \param filename
  */
 DeviceName DeviceNameManager::filenameToDeviceName(String filename) {
   // strip the prefix off

--- a/src/DeviceNameManager.h
+++ b/src/DeviceNameManager.h
@@ -24,12 +24,12 @@
 #include <ArduinoJson.h>
 
 /**
- * Tuple of device name and ID
+ * \brief Tuple of device name and ID
  */
 struct DeviceName
 {
-  String name;
-  String device;
+  String name; //!< Human readable name
+  String device; //!< Device ID
 
   DeviceName(String device, String name): name(name), device(device){}
 };
@@ -37,7 +37,7 @@ struct DeviceName
 
 
 /**
- * Class to manage human readable names for devices
+ * \brief Class to manage human readable names for devices
  */
 class DeviceNameManager
 {
@@ -48,7 +48,6 @@ class DeviceNameManager
 
     static void enumerateDeviceNames(JsonDocument& doc);
 
-
   private:
     static void deviceNameFilename(char* filename, const char* device);
     static DeviceName filenameToDeviceName(String filename);
@@ -56,4 +55,3 @@ class DeviceNameManager
     static const char filenamePrefix[];
     static constexpr int prefixLength();
 };
-

--- a/src/ESP_WiFi.cpp
+++ b/src/ESP_WiFi.cpp
@@ -65,9 +65,7 @@ void mdns_reset() {
 
     MDNS.end();
 
-    if (!MDNS.begin(mdns_id.c_str())) {
-        //Log.error(F("Error resetting MDNS responder."));
-    } else {
+    if (MDNS.begin(mdns_id.c_str())) {
         //Log.notice(F("mDNS responder restarted, hostname: %s.local." CR), WiFi.getHostname());
         // mDNS will stop responding after awhile unless we query the specific service we want
         MDNS.addService("brewpi", "tcp", 23);
@@ -75,6 +73,11 @@ void mdns_reset() {
         MDNS.addServiceTxt("brewpi", "tcp", "branch", "legacy");
         MDNS.addServiceTxt("brewpi", "tcp", "version", Config::Version::release);
         MDNS.addServiceTxt("brewpi", "tcp", "revision", FIRMWARE_REVISION);
+
+        if(Config::Prometheus::enable())
+          MDNS.addService("brewpi_metrics", "tcp", Config::Prometheus::port);
+    } else {
+        //Log.error(F("Error resetting MDNS responder."));
     }
 }
 

--- a/src/PromServer.cpp
+++ b/src/PromServer.cpp
@@ -1,0 +1,186 @@
+#include "Config.h"
+
+#include "DeviceManager.h"
+#include "DeviceNameManager.h"
+#include "PromServer.h"
+#include "TempControl.h"
+#include "TemperatureFormats.h"
+#include "Ticks.h"
+
+const char PromServer::metricsTemplate[] PROGMEM =
+    R"PROM(# HELP brewpi_uptime_seconds Number of seconds since the last hardware reset
+# TYPE brewpi_uptime_seconds counter
+brewpi_uptime_seconds %UPTIME%
+
+# HELP brewpi_state Status of a controller actor
+# TYPE brewpi_state gauge
+brewpi_state{actor="cooler"} %COOLER_STATUS%
+brewpi_state{actor="heater"} %HEATER_STATUS%
+
+# HELP brewpi_target Target temperature
+# TYPE brewpi_target gauge
+brewpi_target{probe="beer"} %BEER_TARGET%
+brewpi_target{probe="fridge"} %FRIDGE_TARGET%
+
+# HELP brewpi_temperature Temperature
+# TYPE brewpi_temperature gauge
+brewpi_temperature{probe="beer"} %BEER_TEMP%
+brewpi_temperature{probe="fridge"} %FRIDGE_TEMP%
+brewpi_temperature{probe="room"} %ROOM_TEMP%
+
+%PROBE_VALUES%
+)PROM";
+
+const char PromServer::probeTemplate[] PROGMEM =
+    R"PROM(brewpi_temperature{probe="%s"} %s
+)PROM";
+
+/**
+ * \brief Storage for caching probe values
+ */
+String PromServer::probeCache = String("");
+
+// Initialize this as a negative so that we immediately are in an expired
+// state, otherwise you have to wait around before the first read actually
+// happens.
+ticks_seconds_t PromServer::dataLastUpdate = 0 - PromServer::cacheTime;
+
+/**
+ * \brief Set up the request endpoints
+ *
+ * Maps paths to handler functions and starts the server.
+ */
+void PromServer::setup() {
+  server.on("/metrics", HTTP_GET, PromServer::metrics);
+
+  server.onNotFound(PromServer::onNotFound);
+  server.begin();
+}
+
+/**
+ * \brief Return 404 for unknown requests
+ * \param request - Request object
+ */
+void PromServer::onNotFound(AsyncWebServerRequest *request) { request->send(404); }
+
+/**
+ * \brief Handle the metrics request
+ * \param request - Request object
+ */
+void PromServer::metrics(AsyncWebServerRequest *request) {
+  request->send_P(200, "text/plain", metricsTemplate, PromServer::templateProcessor);
+}
+
+/**
+ * \brief Supply template placeholder values
+ *
+ * Used by AsyncWebServer when handling the metrics response to supply values
+ * for the placeholders used in the PromServer::metricsTemplate template
+ * string.
+ *
+ * \param val - Placeholder string being replaced
+ * \return Replacement value.  If a defined replacement for `val` isn't known,
+ * an empty string is returned.
+ */
+String PromServer::templateProcessor(const String &var) {
+  if (var == "UPTIME")
+    return String(ticks.seconds());
+
+  // Temp control state
+  if (var == "COOLER_STATUS")
+    return tempControl.stateIsCooling() ? "1" : "0";
+
+  if (var == "HEATER_STATUS")
+    return tempControl.stateIsHeating() ? "1" : "0";
+
+  if (var == "BEER_TEMP")
+    return formatProbeTemp(tempControl.getBeerTemp());
+
+  if (var == "BEER_TARGET")
+    return formatProbeTemp(tempControl.getBeerSetting());
+
+  if (var == "FRIDGE_TEMP")
+    return formatProbeTemp(tempControl.getFridgeTemp());
+
+  if (var == "FRIDGE_TARGET")
+    return formatProbeTemp(tempControl.getFridgeSetting());
+
+  if (var == "ROOM_TEMP")
+    return formatProbeTemp(tempControl.getRoomTemp());
+
+  // Probe readings
+  if (var == "PROBE_VALUES")
+    return probeValues();
+
+  return String();
+}
+
+/**
+ * \brief Format a probe value into a String
+ *
+ * The Prometheus format wants `NaN` to be used to indicate a missing/invalid
+ * data. tempToString() uses `null`.  This method patches the output value to
+ * replace `null` with `NaN`
+ *
+ * \param temp - Temperature value to format
+ * \return String representation of temperature
+ */
+String PromServer::formatProbeTemp(const temperature temp) {
+  char buf[10];
+  tempToString(buf, temp, Config::TempFormat::fixedPointDecimals, Config::TempFormat::maxLength);
+  const String ret = String(buf);
+
+  // Prometheus wants 'NaN' to for null data
+  if (ret.equals("null"))
+    return String("NaN");
+
+  return ret;
+}
+
+/**
+ * \brief Invalidate the probe values cache
+ */
+void PromServer::invalidateCache() {
+  if (Config::Prometheus::enable())
+    PromServer::dataLastUpdate = 0 - PromServer::cacheTime;
+}
+
+/**
+ * \brief Provide metrics strings for all probes
+ *
+ * Uses PromServer::probeTemplate to produce metrics for every attached temp
+ * probe, even those that aren't used in the control loop. If the device has a
+ * human readable name registered with DeviceNameManager, it will be reported.
+ *
+ * Because reading all probes on the OneWire bus takes a while, this will cache
+ * the values internally.
+ *
+ * \see PromServer::cacheTime
+ * \return Formatted metrics string
+ */
+String PromServer::probeValues() {
+  if (ticks.timeSince(dataLastUpdate) > PromServer::cacheTime) {
+    DynamicJsonDocument doc(1024);
+    deviceManager.rawDeviceValues(doc);
+
+    JsonArray root = doc.as<JsonArray>();
+    probeCache = String("");
+
+    for (JsonVariant probe : root) {
+      String devName(probe["device"].as<const char *>());
+      String humanName = DeviceNameManager::getDeviceName(devName.c_str());
+
+      char buffer[256];
+      sprintf_P(buffer, probeTemplate, humanName.c_str(), probe["value"].as<const char *>());
+
+      probeCache += buffer;
+    }
+
+    // Update the cache timestamp
+    dataLastUpdate = ticks.seconds();
+  }
+
+  return probeCache;
+}
+
+PromServer promServer;

--- a/src/PromServer.h
+++ b/src/PromServer.h
@@ -1,0 +1,83 @@
+#pragma once
+#include "Brewpi.h"
+#include "TemperatureFormats.h"
+#include "Ticks.h"
+
+#if defined(ESP32)
+#include "AsyncTCP.h"
+#else
+#include "ESPAsyncTCP.h"
+#endif
+
+#include "ESPAsyncWebServer.h"
+
+/**
+ * \brief A server for handling Prometheus metrics endpoint
+ *
+ * Implements the Prometheus [metrics
+ * format](https://prometheus.io/docs/instrumenting/exposition_formats/).
+ * Allows data gathering using an industry standard metrics system.  This opens
+ * the possibility of more powerful reporting & alerting.
+ *
+ * Because enumerating and reading probes can take a relatively long time, this
+ * class implements a cache so that subsequent data requests will use the
+ * cached value.  This cache only applies to the probe values, not the entire
+ * metrics response.  External code can use PromServer::invalidateCache() to
+ * force cache updates.
+ */
+class PromServer {
+public:
+  void setup();
+  static void onNotFound(AsyncWebServerRequest *request);
+  static void metrics(AsyncWebServerRequest *request);
+  static String templateProcessor(const String &var);
+  static void invalidateCache();
+
+private:
+  /**
+   * \brief ESPAsyncWebServer connection listener.
+   *
+   * Handles incoming requests to the Prometheus port and dispatches to handler
+   * methods.
+   * \see https://github.com/me-no-dev/ESPAsyncWebServer
+   */
+  AsyncWebServer server = AsyncWebServer(Config::Prometheus::port);
+  static String probeCache;
+
+  /**
+   * \brief Template string for the metrics data.
+   *
+   * Placeholders values (surrounded by `%` chars) are replaced at runtime using
+   * PromServer::templateProcessor().
+   *
+   * \see templateProcessor()
+   */
+  static const char metricsTemplate[];
+
+  /**
+   * \brief Template for an individual probe value
+   *
+   * Used to fill the PROBE_VALUES section of metricsTemplate for each
+   * enumerated probe.
+   *
+   * \see probeValues()
+   */
+  static const char probeTemplate[];
+
+  static String formatProbeTemp(const temperature temp);
+  static String probeValues();
+
+  /**
+   * \brief How long to cache probe readings
+   */
+  static constexpr auto cacheTime = 300;
+
+  /**
+   * \brief Tick count of the last time the probe cache was built.
+   *
+   * Used to track the expiration of the probe cache.
+   */
+  static ticks_seconds_t dataLastUpdate;
+};
+
+extern PromServer promServer;

--- a/src/brewpi-esp8266.cpp
+++ b/src/brewpi-esp8266.cpp
@@ -22,6 +22,7 @@
 #include "EepromFormat.h"
 #include "ESP_WiFi.h"
 #include "CommandProcessor.h"
+#include "PromServer.h"
 
 #if BREWPI_SIMULATE
 #include "Simulator.h"
@@ -140,6 +141,9 @@ void setup()
 	display.clear();
 	display.printStationaryText();
 	display.printState();
+
+  if(Config::Prometheus::enable())
+    promServer.setup();
 
 //	rotaryEncoder.init();
 


### PR DESCRIPTION
Adds (optional) support for Prometheus metrics endpoint. As currently configured, it is enabled whenever WiFi is active.  

Probes are reported using either their ID/OneWire address, or the name registered with DeviceNameManager.