### PR TITLE
Add WiFi information command

### DIFF
--- a/src/CommandProcessor.h
+++ b/src/CommandProcessor.h
@@ -30,7 +30,8 @@ public:
   static void receiveCommand();
 
 private:
-  static void invalidCommand(char inByte);
+  static void invalidCommand(const char inByte);
+  static void commandNotImplemented(const char command, const String message);
   static void versionInfo();
 
   static void sendControlSettings();
@@ -50,6 +51,7 @@ private:
   static void listDevices();
   static void listHardware();
   static void resetWiFi();
+  static void wifiInfo();
 
   // LCD
   static void toggleBacklight();

--- a/src/ESP_WiFi.cpp
+++ b/src/ESP_WiFi.cpp
@@ -35,16 +35,13 @@ extern void handleReset();  // Terrible practice. In brewpi-esp8266.cpp.
 
 /**
  * \brief Callback notifying us of the need to save config
+ * \ingroup wifi
  */
 void saveConfigCallback() {
     Serial.println("Should save config");
     shouldSaveConfig = true;
 }
 
-
-/**
- * \brief Initialize the telnet server
- */
 void initWifiServer() {
   server.begin();
   server.setNoDelay(true);
@@ -151,6 +148,10 @@ void initialize_wifi() {
     WiFi.setAutoReconnect(true);
 }
 
+void wifi_connection_info(JsonDocument& doc) {
+  doc["ssid"] = WiFi.SSID();
+  doc["signalStrength"] = WiFi.RSSI();
+}
 
 void display_connect_info_and_create_callback() {
 #if defined(ESP8266)
@@ -162,11 +163,6 @@ void display_connect_info_and_create_callback() {
 }
 
 
-/**
- * \brief Handle incoming WiFi client connections.
- *
- * This also handles WiFi network reconnects if the network was disconnected.
- */
 void wifi_connect_clients() {
     static unsigned long last_connection_check = 0;
 

--- a/src/ESP_WiFi.h
+++ b/src/ESP_WiFi.h
@@ -2,11 +2,18 @@
 // Created by John Beeler on 1/12/20.
 //
 #pragma once
+#include <ArduinoJson.h>
 
 /**
  * \file ESP_WiFi.h
  *
- * \brief WiFi configuration
+ * \defgroup wifi WiFi Configuration & Management
+ * \brief WiFi configuration functions
+ *
+ * Various helper functions for interacting with the WiFi configuration.
+ *
+ * \addtogroup wifi
+ * @{
  */
 
 // This library always needs to get loaded, as we're going to need to interact with the radio regardless of whether
@@ -20,10 +27,39 @@
 
 
 
-void initialize_wifi();  // If WiFi is enabled, this sets it up. Otherwise, it disconnects the radio.
-void display_connect_info_and_create_callback(); // Display the WiFi splash screen & trigger reconnection callback
+/**
+ * \brief Initialize the WiFi client
+ *
+ * If WiFi is enabled, this sets it up. Otherwise, it disconnects the radio.
+ */
+void initialize_wifi();
+
+/**
+ * \brief Display the WiFi splash screen & trigger reconnection callback.
+ */
+void display_connect_info_and_create_callback();
+
+/**
+ * \brief Handle incoming WiFi client connections.
+ *
+ * This also handles WiFi network reconnects if the network was disconnected.
+ */
 void wifi_connect_clients();
+
+/**
+ * \brief Initialize the telnet server
+ */
 void initWifiServer();
+
+
+/**
+ * \brief Get current WiFi connection information, in JsonDocument format
+ *
+ * \param doc - JsonDocument to populate.
+ */
+void wifi_connection_info(JsonDocument& doc);
 
 extern WiFiServer server;
 extern WiFiClient serverClient;
+
+/** @} */


### PR DESCRIPTION
Adds the 'W' command, which will dump the current connection's SSID &
signal strength.  Example output of new `W` command:

```W:{"ssid":"devferment","signalStrength":-32}```

Also improves some doxygen comments in ESP_WiFi.*

This might fix #18, depending on the exact intent of that issue. (It's unclear if that was meant to be a LCD display feature, or just general "this info needs to be somewhere")