### PR TITLE
Lock ESP32-S2 targets to Arduino v2.0.6

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -210,6 +210,11 @@ monitor_filters = esp8266_exception_decoder, default
 platform = espressif32
 board = lolin_s2_mini
 framework = ${common.framework}
+; v4.4.4 of esp-idf introduces a bug in the IIC implementation that causes MASSIVE delays
+; in the IIC bus on the S2 (meaning that writes to the LCD grind the controller to a halt). 
+; This is a workaround until the bug is fixed.
+platform_packages =
+    platformio/framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#2.0.6
 ; For esp32_s2_wifi we want to enable LCD support, IIC support, and WiFi support
 ; There is no Bluetooth support on this chip. 
 build_flags =
@@ -238,6 +243,11 @@ monitor_filters =
 platform = espressif32
 board = lolin_s2_mini
 framework = ${common.framework}
+; v4.4.4 of esp-idf introduces a bug in the IIC implementation that causes MASSIVE delays
+; in the IIC bus on the S2 (meaning that writes to the LCD grind the controller to a halt). 
+; This is a workaround until the bug is fixed.
+platform_packages =
+    platformio/framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#2.0.6
 ; For esp32_s2_serial we want to enable LCD support, IIC support, and Serial support
 ; There is no Bluetooth support on this chip. 
 build_flags =


### PR DESCRIPTION
Arduino versions past v2.0.6 are based on ESP-IDF v4.4.4 which introduces a bug in the IIC implementation causing delays in every write to IIC LCDs. Reverting to v2.0.6 eliminates this bug.