### PR TITLE
Track Gravity on Tilts

### DIFF
--- a/src/EepromStructs.cpp
+++ b/src/EepromStructs.cpp
@@ -17,6 +17,9 @@
 #include "PiLink.h"
 #include "Display.h"
 
+#ifdef HAS_BLUETOOTH
+NimBLEAddress NoTiltDevice = NimBLEAddress("00:00:00:00:00:00");
+#endif
 
 
 void JSONSaveable::writeJsonToFile(const char *filename, const ArduinoJson::JsonDocument& json_doc) {
@@ -293,6 +296,10 @@ void ExtendedSettings::setDefaults() {
     invertTFT = false;
     glycol = false;
     largeTFT = false;
+#ifdef HAS_BLUETOOTH
+    tiltGravSensor = NoTiltDevice;
+#endif
+
 }
 
 
@@ -304,6 +311,9 @@ void ExtendedSettings::toJson(DynamicJsonDocument &doc) {
     doc[ExtendedSettingsKeys::invertTFT] = invertTFT;
     doc[ExtendedSettingsKeys::glycol] = glycol;
     doc[ExtendedSettingsKeys::largeTFT] = largeTFT;
+#ifdef HAS_BLUETOOTH
+    doc[ExtendedSettingsKeys::tiltGravSensor] = tiltGravSensor.toString();
+#endif
 }
 
 /**
@@ -331,7 +341,9 @@ void ExtendedSettings::loadFromSpiffs() {
     if(json_doc.containsKey(ExtendedSettingsKeys::invertTFT)) invertTFT = json_doc[ExtendedSettingsKeys::invertTFT];
     if(json_doc.containsKey(ExtendedSettingsKeys::glycol)) glycol = json_doc[ExtendedSettingsKeys::glycol];
     if(json_doc.containsKey(ExtendedSettingsKeys::largeTFT)) largeTFT = json_doc[ExtendedSettingsKeys::largeTFT];
-
+#ifdef HAS_BLUETOOTH
+    if(json_doc.containsKey(ExtendedSettingsKeys::tiltGravSensor)) tiltGravSensor = NimBLEAddress(json_doc[ExtendedSettingsKeys::tiltGravSensor].as<std::string>());
+#endif
 }
 
 /**
@@ -356,7 +368,13 @@ void ExtendedSettings::processSettingKeypair(JsonPair kv) {
     setGlycol(kv.value().as<bool>());
   } else if (kv.key() == ExtendedSettingsKeys::largeTFT) {
     setLargeTFT(kv.value().as<bool>());
+  } 
+  #ifdef HAS_BLUETOOTH
+  else if (kv.key() == ExtendedSettingsKeys::tiltGravSensor) {
+    NimBLEAddress addr = NimBLEAddress(kv.value().as<std::string>());
+    setTiltGravSensor(addr);
   }
+  #endif
 }
 
 /**
@@ -398,6 +416,18 @@ void ExtendedSettings::setInvertTFT(bool setting) {
     display.printStationaryText();
 	display.printState();
 }
+
+
+#ifdef HAS_BLUETOOTH
+/**
+ * \brief Set the Tilt color to be used as the gravity sensor
+ *
+ * \param setting - The new setting
+ */
+void ExtendedSettings::setTiltGravSensor(NimBLEAddress setting) {
+    tiltGravSensor = setting;
+}
+#endif
 
 
 /**

--- a/src/EepromStructs.h
+++ b/src/EepromStructs.h
@@ -207,6 +207,12 @@ public:
     bool largeTFT;  //<! Whether or not to use a large TFT
     bool glycol;  //<! Whether or not to use glycol mode
 
+    #ifdef HAS_BLUETOOTH
+    NimBLEAddress tiltGravSensor; //<! The color of the Tilt hydrometer used for gravity
+    void setTiltGravSensor(NimBLEAddress setting);
+    #endif
+
+
     void toJson(DynamicJsonDocument &doc);
     void storeToSpiffs();
     void loadFromSpiffs();
@@ -267,3 +273,7 @@ public:
     static constexpr auto filename = "/upstreamSettings.json";
 private:
 };
+
+#ifdef HAS_BLUETOOTH
+extern NimBLEAddress NoTiltDevice;
+#endif

--- a/src/JsonKeys.h
+++ b/src/JsonKeys.h
@@ -129,6 +129,7 @@ constexpr auto eepromReset = "confirmReset";
 constexpr auto invertTFT = "invertTFT";
 constexpr auto glycol = "glycol";
 constexpr auto largeTFT = "largeTFT";
+constexpr auto tiltGravSensor = "tiltGravSensor";
 }; // namespace ExtendedSettingsKeys
 
 

--- a/src/displays/DisplayTFT_ILI.cpp
+++ b/src/displays/DisplayTFT_ILI.cpp
@@ -43,6 +43,10 @@
 
 //#include <XPT2046_Touchscreen.h>
 
+#ifdef HAS_BLUETOOTH
+#include "wireless/BTScanner.h"
+#endif
+
 
 bool toggleBacklight;
 
@@ -141,6 +145,10 @@ void LcdDisplay::printAllTemperatures(){
     printBeerSet();
     printFridgeTemp();
     printFridgeSet();
+
+#ifdef HAS_BLUETOOTH
+    printGravity();
+#endif
 }
 
 void LcdDisplay::setDisplayFlags(uint8_t newFlags) {
@@ -474,19 +482,26 @@ void LcdDisplay::printGravity(){
     clearForText(GRAVITY_START_X, GRAVITY_START_Y, ILI9341_BLACK, GRAVITY_HEADER_FONT_SIZE, 5);
 
     tft->setCursor(GRAVITY_START_X, GRAVITY_HEADER_START_Y);
-    tft->print("Gravity");
 
+    tilt* grav_sensor = bt_scanner.get_tilt(extendedSettings.tiltGravSensor);
+    if(grav_sensor != nullptr) {
+        tft->print("Gravity");
 
-    // Print the Gravity
-    double grav = 80.0 / 1000.0;
+        // Print the Gravity
+        double grav = grav_sensor->getGravity() / 1000.0;
 
-
-
-    char grav_text[6];
-    snprintf(grav_text, 6, "%05.3f", grav);
-    tft->setTextSize(GRAVITY_FONT_SIZE);
-    tft->setCursor(GRAVITY_START_X, GRAVITY_START_Y);
-    tft->print(grav_text);
+        char grav_text[6];
+        snprintf(grav_text, 6, "%05.3f", grav);
+        tft->setTextSize(GRAVITY_FONT_SIZE);
+        tft->setCursor(GRAVITY_START_X, GRAVITY_START_Y);
+        tft->print(grav_text);
+    } else {
+        // Clear the gravity section of the screen
+        tft->print("       ");
+        tft->setTextSize(GRAVITY_FONT_SIZE);
+        tft->setCursor(GRAVITY_START_X, GRAVITY_START_Y);
+        tft->print("     ");
+    }
 }
 #endif
 

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -315,6 +315,22 @@ uint8_t processExtendedSettingsJson(const DynamicJsonDocument& json, bool trigge
     }
 
 
+#ifdef HAS_BLUETOOTH
+    // Tilt Gravity Sensor
+    if(json.containsKey(ExtendedSettingsKeys::tiltGravSensor)) {
+        if(json[ExtendedSettingsKeys::tiltGravSensor].is<std::string>()) {
+            // Validate that it's valid
+            if(extendedSettings.tiltGravSensor != json[ExtendedSettingsKeys::tiltGravSensor].as<std::string>()) {
+                extendedSettings.setTiltGravSensor(NimBLEAddress(json[ExtendedSettingsKeys::tiltGravSensor].as<std::string>()));
+                saveSettings = true;
+            }
+        } else {
+            Log.warning(F("Invalid [tiltGravSensor]:(%s) received (wrong type).\r\n"), json[ExtendedSettingsKeys::tiltGravSensor]);
+            failCount++;
+        }
+    }
+#endif
+
     // SETTINGS_CHOICE
     if(json.containsKey(MinTimesKeys::SETTINGS_CHOICE)) {
         if(json[MinTimesKeys::SETTINGS_CHOICE].is<uint8_t>()) {

--- a/src/rest/rest_send.cpp
+++ b/src/rest/rest_send.cpp
@@ -430,7 +430,7 @@ bool restHandler::send_status() {
 #ifdef HAS_BLUETOOTH
         tilt* grav_sensor = bt_scanner.get_tilt(extendedSettings.tiltGravSensor);
         if(grav_sensor != nullptr) {
-            doc["gravity"] = grav_sensor->getGravity();
+            doc["gravity_raw"] = grav_sensor->getGravity();
         }
 #endif
 

--- a/src/rest/rest_send.cpp
+++ b/src/rest/rest_send.cpp
@@ -18,6 +18,10 @@
 #include "JsonKeys.h"
 #include "SettingLoader.h"
 
+#ifdef HAS_BLUETOOTH
+#include "wireless/BTScanner.h"
+#endif
+
 
 restHandler rest_handler; // Global data sender
 
@@ -422,6 +426,13 @@ bool restHandler::send_status() {
         doc["temps"] = temps;
         doc["temp_format"] = String(tempControl.cc.tempFormat);
         doc["mode"] = String(tempControl.cs.mode);
+
+#ifdef HAS_BLUETOOTH
+        tilt* grav_sensor = bt_scanner.get_tilt(extendedSettings.tiltGravSensor);
+        if(grav_sensor != nullptr) {
+            doc["gravity"] = grav_sensor->getGravity();
+        }
+#endif
 
         // Serialize the JSON document
         serializeJson(doc, payload);


### PR DESCRIPTION
This PR adds the ability for a Tilt that is assigned as a beer temperature sensor to also track the beer's specific gravity. This gravity will then be included in messages that are sent to Fermentrack 2 as well as displayed in the lower right corner of ILI TFTs. 