### PR TITLE
Finish eSPI Screen Support

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -17,7 +17,7 @@ framework = arduino
 ; The default platform & platform package only applies to ESP32 derivatives
 platform = espressif32
 platform_packages = 
-    framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#3.0.4
+    framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#3.0.7
     platformio/framework-arduinoespressif32-libs @ https://github.com/espressif/esp32-arduino-libs.git#idf-release/v5.1
 lib_deps =
     https://github.com/tzapu/WiFiManager.git#0d84861270c3cd64f72a4eaf34443ee580d2547e ; Anchor to latest commit as of 8/7/24
@@ -248,50 +248,51 @@ build_type = ${common.build_type}
 monitor_filters =
     esp32_exception_decoder
 
-; [env:esp32_wifi_espi]
-; board = m5stick-c
-; platform = ${common.platform}
-; framework = ${common.framework}
-; platform_packages = ${common.platform_packages}
-; ; board_build.arduino.upstream_packages = no
-; ; For esp32_wifi_tft we want to enable LCD support, TFT support, and WiFi support
-; build_flags =
-;     ${common.build_flags}
-;     -DBREWPI_LCD
-;     -DBREWPI_TFT
-;     -DBREWPI_TFT_ESPI
-;     -DHAS_AXP192
-;     -DESP8266_WiFi
-;     -DHAS_BLUETOOTH
-;     -DEXTERN_SENSOR_ACTUATOR_SUPPORT
-;     ; -DENABLE_PROMETHEUS_SERVER
-;     -DENABLE_HTTP_INTERFACE
-;     -DCONFIG_BT_NIMBLE_ROLE_PERIPHERAL_DISABLED
-;     -DCONFIG_BT_NIMBLE_ROLE_BROADCASTER_DISABLED
-;     -DCONFIG_BT_NIMBLE_PINNED_TO_CORE=1
-;     -DESP32_STOCK
-;     -DUSER_SETUP_LOADED=1
-;     -DST7789_DRIVER=1
-;     -DTFT_WIDTH=135
-;     -DTFT_HEIGHT=240
-;     -DCGRAM_OFFSET=1
-;     -DTFT_MISO=-1
-;     -DTFT_MOSI=15
-;     -DTFT_SCLK=13
-;     -DTFT_CS=5
-;     -DTFT_DC=23
-;     -DTFT_RST=18
-;     -DLOAD_GFXFF=1
-;     -DSMOOTH_FONT=1
+[env:esp32_wifi_espi]
+board = esp32dev
+platform = ${common.platform}
+framework = ${common.framework}
+platform_packages = ${common.platform_packages}
+; board_build.arduino.upstream_packages = no
+; For esp32_wifi_tft we want to enable LCD support, TFT support, and WiFi support
+build_flags =
+    ${common.build_flags}
+    -DBREWPI_LCD
+    -DBREWPI_TFT
+    -DBREWPI_TFT_ESPI
+    -DHAS_AXP192
+    -DESP8266_WiFi
+    -DHAS_BLUETOOTH
+    -DEXTERN_SENSOR_ACTUATOR_SUPPORT
+    ; -DENABLE_PROMETHEUS_SERVER
+    -DENABLE_HTTP_INTERFACE
+    -DCONFIG_BT_NIMBLE_ROLE_PERIPHERAL_DISABLED
+    -DCONFIG_BT_NIMBLE_ROLE_BROADCASTER_DISABLED
+    -DCONFIG_BT_NIMBLE_PINNED_TO_CORE=1
+    -DESP32_STOCK
+    -DUSER_SETUP_LOADED=1
+    -DST7789_DRIVER=1
+    -DTFT_WIDTH=135
+    -DTFT_HEIGHT=240
+    -DCGRAM_OFFSET=1
+    -DTFT_MISO=-1
+    -DTFT_MOSI=15
+    -DTFT_SCLK=13
+    -DTFT_CS=5
+    -DTFT_DC=23
+    -DTFT_RST=18
+    -DLOAD_GFXFF=1
+    -DSMOOTH_FONT=1
 
-; lib_deps =
-;     ${common.lib_deps}
-;     ${common.lib_deps_bluetooth}
-;     bodmer/TFT_eSPI @ 2.5.34 ; https://github.com/Bodmer/TFT_eSPI.git
-; upload_speed = 1500000
-; monitor_speed = ${common.monitor_speed}
-; board_build.partitions = 4mb_inc_ota.csv
-; ;board_build.filesystem = spiffs
-; build_type = ${common.build_type}
-; monitor_filters =
-;     esp32_exception_decoder
+lib_deps =
+    ${common.lib_deps}
+    ${common.lib_deps_bluetooth}
+    ; bodmer/TFT_eSPI @ 2.5.43 ; https://github.com/Bodmer/TFT_eSPI.git
+    https://github.com/Bodmer/TFT_eSPI.git#5793878d24161c1ed23ccb136f8564f332506d53 ; master as of 7/6/24
+upload_speed = 1500000
+monitor_speed = ${common.monitor_speed}
+board_build.partitions = 4mb_no_ota.csv
+;board_build.filesystem = spiffs
+build_type = ${common.build_type}
+monitor_filters =
+    esp32_exception_decoder

--- a/src/brewpi-esp8266.cpp
+++ b/src/brewpi-esp8266.cpp
@@ -242,7 +242,7 @@ void brewpiLoop()
 #ifdef HAS_BLUETOOTH
 if(bt_scanner.scanning_failed()) {
 #ifdef ENABLE_HTTP_INTERFACE
-  rest_handler.send_bluetooth_crash_report();
+  // rest_handler.send_bluetooth_crash_report();
   // TODO - Figure out if we want to keep this here
 #endif
   esp_restart();

--- a/src/displays/DisplayTFT_eSPI.cpp
+++ b/src/displays/DisplayTFT_eSPI.cpp
@@ -182,29 +182,14 @@ void LcdDisplay::printFridgeSet(){
 }
 
 void LcdDisplay::printTemperatureAtMonoChars(uint8_t x_chars, uint8_t y_chars, temperature temp){
-    uint16_t x = x_chars * tft.textWidth("A", GFXFF) + 3;
-    uint16_t y = (y_chars) * tft.fontHeight(GFXFF) + 2;
+    char tempString[9];
+    char tempBuf[9];
 
-    printTemperature(temp, x, y);
-}
-
-void LcdDisplay::printAtMonoChars(uint8_t x_chars, uint8_t y_chars, const char *text){
-    uint16_t x = x_chars * tft.textWidth("A", GFXFF) + 3;
-    uint16_t y = (y_chars) * tft.fontHeight(GFXFF) + 2;
-
-    tft.drawString(text, x, y);
-}
-
-
-void LcdDisplay::printTemperature(temperature temp, uint8_t start_x, uint8_t start_y){
     if (temp==INVALID_TEMP) {
-        tft.drawString("  --.-", start_x, start_y);
+        printAtMonoChars(x_chars, y_chars, "  --.-");
         return;
     }
 
-
-    char tempString[9];
-    char tempBuf[9];
     tempToString(tempString, temp, 1 , 9);
 
     // Pad the width 
@@ -223,7 +208,14 @@ void LcdDisplay::printTemperature(temperature temp, uint8_t start_x, uint8_t sta
             break;
     }
 
-    tft.drawString(tempBuf, start_x, start_y);
+    printAtMonoChars(x_chars, y_chars, tempBuf);
+}
+
+void LcdDisplay::printAtMonoChars(uint8_t x_chars, uint8_t y_chars, const char *text){
+    uint16_t x = x_chars * tft.textWidth("A", GFXFF) + 3;
+    uint16_t y = (y_chars) * tft.fontHeight(GFXFF) + 2;
+
+    tft.drawString(text, x, y);
 }
 
 //print the stationary text on the lcd.

--- a/src/displays/DisplayTFT_eSPI.cpp
+++ b/src/displays/DisplayTFT_eSPI.cpp
@@ -263,21 +263,15 @@ void LcdDisplay::printMode(){
     }
 }
 
-// void LcdDisplay::printIPAddressInfo(){
-//     tft.setTextColor(ILI9341_WHITE, ILI9341_BLACK);
-//     tft.setTextSize(IP_ADDRESS_FONT_SIZE);
-//     clearForText(IP_ADDRESS_START_X, IP_ADDRESS_START_Y, ILI9341_BLACK, MODE_FONT_SIZE, 21);
+void LcdDisplay::printIPAddressInfo(){
+    printAtMonoChars(0, 5, "IP: ");
 
-//     tft.setCursor(IP_ADDRESS_START_X, IP_ADDRESS_START_Y);
-//     tft.print("IP Address: ");
-
-//     if(WiFi.isConnected()) {
-//         tft.print(WiFi.localIP());
-//     } else {
-//         tft.print("Disconnected");
-//     }
-
-// }
+    if(WiFi.isConnected()) {
+        printAtMonoChars(4, 5, WiFi.localIP().toString().c_str());
+    } else {
+        printAtMonoChars(4, 5, "Disconnected   ");
+    }
+}
 
 
 uint8_t LcdDisplay::printTime(uint16_t time) {

--- a/src/displays/DisplayTFT_eSPI.cpp
+++ b/src/displays/DisplayTFT_eSPI.cpp
@@ -470,16 +470,16 @@ Fridge 58.7  44.9 °F
 Cooling for    04m01
 */
 
-std::string getline_temp_string(temperature temp) {
+std::string LcdDisplay::getline_temp_string(temperature temp) {
     if (temp==INVALID_TEMP) {
-        std::string str(" --.-");
+        std::string str("  --.-");
         return str;
     }
 
     char tempString[9];
     tempToString(tempString, temp, 1 , 9);
     std::string str(tempString);
-    while(str.length() < 5)
+    while(str.length() <= 5)
         str.insert(0, " ");
     return str;
 }

--- a/src/displays/DisplayTFT_eSPI.h
+++ b/src/displays/DisplayTFT_eSPI.h
@@ -99,6 +99,7 @@ private:
     char textCache[TFT_ROWS][TFT_COLUMNS+1];  // Cache to reduce flickering
 
     uint8_t printTime(uint16_t time);
+    std::string getline_temp_string(temperature temp);
 };
 
 extern TFT_eSPI tft;

--- a/src/displays/DisplayTFT_eSPI.h
+++ b/src/displays/DisplayTFT_eSPI.h
@@ -16,7 +16,9 @@
 #undef DISABLE_ALL_LIBRARY_WARNINGS
 
 #define FF17                    &FreeMono9pt7b
-#define GFXFF                   1  // THis can probably be removed
+#define GFXFF                   1  // This can probably be removed
+#define TFT_ROWS     6
+#define TFT_COLUMNS  20
 
 
 class LcdDisplay
@@ -92,6 +94,7 @@ private:
 
     uint8_t stateOnDisplay;
     uint8_t flags;
+    char textCache[TFT_ROWS][TFT_COLUMNS+1];  // Cache to reduce flickering
 
     uint8_t printTime(uint16_t time);
 };

--- a/src/displays/DisplayTFT_eSPI.h
+++ b/src/displays/DisplayTFT_eSPI.h
@@ -35,7 +35,7 @@ public:
     printState();
     printAllTemperatures();
     printMode();
-    // printIPAddressInfo();
+    printIPAddressInfo();
 #ifdef HAS_BLUETOOTH
     // printGravity();
 #endif
@@ -50,7 +50,6 @@ public:
 
     // print mode on the right location on the first line, after Mode:
     void printMode();
-    // void printIPAddressInfo();
 
     void setDisplayFlags(uint8_t newFlags);
     uint8_t getDisplayFlags() { return flags; };
@@ -69,6 +68,9 @@ public:
 
     // print the current state on the last line of the LCD
     void printState();
+
+    // print the IP address on row 6 
+    void printIPAddressInfo();
 
     void getLine(uint8_t lineNumber, char * buffer);
 


### PR DESCRIPTION
This adds support for eSPI screen types on ESP32-based devices. These boards are [commonly sold](https://www.amazon.com/T-Display-Bluetooth-Compatible-Development-Arduino-CH9102F/dp/B0DCB6X3V1/) as a single unit, where the screen comes preattached to the controller. Enabling use of these boards with BrewPi-ESP will allow someone interested in a solder-free build to not need to assemble anything if they choose.