### PR TITLE
Update ESP32-S2 to use LittleFS instead of SPIFFS

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -184,7 +184,7 @@ monitor_filters = esp8266_exception_decoder, default
 ; upload_speed = ${common.upload_speed}
 ; monitor_speed = ${common.monitor_speed}
 ; board_build.partitions = 4mb_inc_ota.csv
-; ;board_build.filesystem = spiffs
+; ;board_build.filesystem = littlefs
 ; build_type = ${common.build_type}
 ; monitor_filters =
 ;     esp32_exception_decoder
@@ -207,7 +207,6 @@ build_flags =
     -DENABLE_HTTP_INTERFACE
     -DEXTERN_SENSOR_ACTUATOR_SUPPORT
     ; -DENABLE_PROMETHEUS_SERVER
-    ; -DENABLE_HTTP_INTERFACE
     -DESP32S2
 lib_deps =
     ${common.lib_deps}
@@ -215,8 +214,7 @@ lib_deps =
 upload_speed = ${common.upload_speed}
 monitor_speed = ${common.monitor_speed}
 board_build.partitions = 4mb_inc_ota.csv
-board_build.filesystem = spiffs
-;board_build.filesystem = littlefs
+board_build.filesystem = littlefs
 build_type = ${common.build_type}
 monitor_filters =
     esp32_exception_decoder
@@ -243,8 +241,7 @@ monitor_filters =
 ; upload_speed = ${common.upload_speed}
 ; monitor_speed = ${common.monitor_speed}
 ; board_build.partitions = 4mb_inc_ota.csv
-; ;board_build.filesystem = spiffs
-; ;board_build.filesystem = littlefs
+; board_build.filesystem = littlefs
 ; build_type = ${common.build_type}
 ; monitor_filters =
 ;     esp32_exception_decoder

--- a/src/ESPEepromAccess.h
+++ b/src/ESPEepromAccess.h
@@ -17,24 +17,8 @@
 
 #pragma once
 
-#if defined(ESP8266)
 #define FILESYSTEM LittleFS
 #include <LittleFS.h>
-
-#elif defined(ESP32S2)
-// #define FILESYSTEM LittleFS
-// #include <LittleFS.h>
-#define FILESYSTEM SPIFFS
-#include <SPIFFS.h>
-
-
-#elif defined(ESP32)
-#define FILESYSTEM LittleFS
-#include <LittleFS.h>
-
-#else
-#error "Not supported!"
-#endif
 
 #include "EepromStructs.h"
 #include "Brewpi.h"  // Only needed for Config:: below


### PR DESCRIPTION
This aligns the ESP32-S2 firmware with all of the other controllers in using LittleFS instead of SPIFFS. 