### PR TITLE
Make resetting on pin toggle optional

### DIFF
--- a/src/ActuatorArduinoPin.cpp
+++ b/src/ActuatorArduinoPin.cpp
@@ -14,7 +14,7 @@ void DigitalPinActuator::setActive(bool active_setting) {
     if (oldActive != active) {
         // We toggled one of the pins, which can cause issues for the display. Delay slightly to let everything settle down, then reinit the display
         delay(100);
-        display.init();
+        display.reset();
         display.printAll();
     }
 

--- a/src/ActuatorArduinoPin.cpp
+++ b/src/ActuatorArduinoPin.cpp
@@ -3,6 +3,7 @@
 #include "Pins.h"
 #include "ActuatorArduinoPin.h"
 #include "Display.h"
+#include "EepromManager.h"  // for extendedSettings
 
 
 void DigitalPinActuator::setActive(bool active_setting) {
@@ -11,8 +12,9 @@ void DigitalPinActuator::setActive(bool active_setting) {
     this->active = active_setting;
     digitalWrite(pin, active_setting^invert ? HIGH : LOW);
 
-    if (oldActive != active) {
-        // We toggled one of the pins, which can cause issues for the display. Delay slightly to let everything settle down, then reinit the display
+    if (oldActive != active && extendedSettings.resetScreenOnPin) {
+        // We toggled one of the pins, which can cause issues for the display. 
+        // Delay slightly to let everything settle down, then reinit the display
         delay(100);
         display.reset();
         display.printAll();

--- a/src/EepromStructs.cpp
+++ b/src/EepromStructs.cpp
@@ -286,6 +286,7 @@ void ExtendedSettings::setDefaults() {
     invertTFT = false;
     glycol = false;
     largeTFT = false;
+    resetScreenOnPin = false;
 #ifdef HAS_BLUETOOTH
     tiltGravSensor = NoTiltDevice;
 #endif
@@ -301,6 +302,7 @@ void ExtendedSettings::toJson(JsonDocument &doc) {
     doc[ExtendedSettingsKeys::invertTFT] = invertTFT;
     doc[ExtendedSettingsKeys::glycol] = glycol;
     doc[ExtendedSettingsKeys::largeTFT] = largeTFT;
+    doc[ExtendedSettingsKeys::resetScreenOnPin] = resetScreenOnPin;
 #ifdef HAS_BLUETOOTH
     doc[ExtendedSettingsKeys::tiltGravSensor] = tiltGravSensor.toString();
 #endif
@@ -331,6 +333,7 @@ void ExtendedSettings::loadFromFilesystem() {
     if(json_doc[ExtendedSettingsKeys::invertTFT].is<bool>()) invertTFT = json_doc[ExtendedSettingsKeys::invertTFT];
     if(json_doc[ExtendedSettingsKeys::glycol].is<bool>()) glycol = json_doc[ExtendedSettingsKeys::glycol];
     if(json_doc[ExtendedSettingsKeys::largeTFT].is<bool>()) largeTFT = json_doc[ExtendedSettingsKeys::largeTFT];
+    if(json_doc[ExtendedSettingsKeys::resetScreenOnPin].is<bool>()) resetScreenOnPin = json_doc[ExtendedSettingsKeys::resetScreenOnPin];
 #ifdef HAS_BLUETOOTH
     // Tilts use address type 1 ("random", which (correctly!) indicates they didn't buy a MAC block)
     if(json_doc[ExtendedSettingsKeys::tiltGravSensor].is<std::string>()) tiltGravSensor = NimBLEAddress(json_doc[ExtendedSettingsKeys::tiltGravSensor].as<std::string>(), 1);
@@ -359,6 +362,8 @@ void ExtendedSettings::processSettingKeypair(JsonPair kv) {
     setGlycol(kv.value().as<bool>());
   } else if (kv.key() == ExtendedSettingsKeys::largeTFT) {
     setLargeTFT(kv.value().as<bool>());
+  } else if (kv.key() == ExtendedSettingsKeys::resetScreenOnPin) {
+    setResetScreenOnPin(kv.value().as<bool>());
   } 
   #ifdef HAS_BLUETOOTH
   else if (kv.key() == ExtendedSettingsKeys::tiltGravSensor) {
@@ -409,6 +414,19 @@ void ExtendedSettings::setInvertTFT(bool setting) {
 	display.printState();
 }
 
+/**
+ * \brief Set if the screen should be reset when an ArduinoActuatorPin (ie. relay) toggles
+ *
+ * \param setting - The new setting
+ */
+void ExtendedSettings::setResetScreenOnPin(bool setting) {
+    resetScreenOnPin = setting;
+
+    // The only thing we must do here is change the setting, but we'll reinit the screen as well 
+    // in case the user is enabling this as a result of their screen being frozen
+    if(setting)
+        display.printAll();
+}
 
 #ifdef HAS_BLUETOOTH
 /**

--- a/src/EepromStructs.h
+++ b/src/EepromStructs.h
@@ -206,6 +206,7 @@ public:
     bool invertTFT;  //<! Whether or not to invert the TFT
     bool largeTFT;  //<! Whether or not to use a large TFT
     bool glycol;  //<! Whether or not to use glycol mode
+    bool resetScreenOnPin;  //<! Whether or not to reset the screen when an ActuatorArduinoPin toggles
 
     #ifdef HAS_BLUETOOTH
     NimBLEAddress tiltGravSensor; //<! The color of the Tilt hydrometer used for gravity
@@ -222,6 +223,7 @@ public:
     void setGlycol(bool setting);
     void setInvertTFT(bool setting);
     void setLargeTFT(bool setting);
+    void setResetScreenOnPin(bool setting);
 
     /**
      * \brief Filename used when reading/writing data to flash

--- a/src/JsonKeys.h
+++ b/src/JsonKeys.h
@@ -129,6 +129,7 @@ constexpr auto eepromReset = "confirmReset";
 constexpr auto invertTFT = "invertTFT";
 constexpr auto glycol = "glycol";
 constexpr auto largeTFT = "largeTFT";
+constexpr auto resetScreenOnPin = "resetScreenOnPin";
 constexpr auto tiltGravSensor = "tiltGravSensor";
 }; // namespace ExtendedSettingsKeys
 

--- a/src/displays/DisplayLcd.cpp
+++ b/src/displays/DisplayLcd.cpp
@@ -89,6 +89,12 @@ void LcdDisplay::init(){
 	lcd.clear();
 }
 
+void LcdDisplay::reset(){
+    // This is called whenever the screen is reset when a relay pin toggles.
+    // For now, just call init()
+    init();
+}
+
 #ifndef UINT16_MAX
 #define UINT16_MAX 65535
 #endif

--- a/src/displays/DisplayLcd.h
+++ b/src/displays/DisplayLcd.h
@@ -58,6 +58,7 @@ class LcdDisplay DISPLAY_SUPERCLASS
   public:
 	// initializes the lcd display
 	DISPLAY_METHOD void init();
+	DISPLAY_METHOD void reset();
 
   /**
    * Print all display content

--- a/src/displays/DisplayTFT_ILI.cpp
+++ b/src/displays/DisplayTFT_ILI.cpp
@@ -123,7 +123,12 @@ void LcdDisplay::init(){
     pinMode(TFT_BACKLIGHT, OUTPUT);
     digitalWrite(TFT_BACKLIGHT, HIGH);
 #endif
+}
 
+void LcdDisplay::reset(){
+    // This is called whenever the screen is reset when a relay pin toggles.
+    // For now, just call init()
+    init();
 }
 
 #ifndef UINT16_MAX

--- a/src/displays/DisplayTFT_ILI.h
+++ b/src/displays/DisplayTFT_ILI.h
@@ -99,6 +99,7 @@ public:
     ~LcdDisplay();
     // initializes the lcd display
     void init();
+    void reset();
 
     void printAll()
     {

--- a/src/displays/DisplayTFT_eSPI.cpp
+++ b/src/displays/DisplayTFT_eSPI.cpp
@@ -125,6 +125,12 @@ void LcdDisplay::init() {
 
 }
 
+void LcdDisplay::reset() {
+    // This is called whenever the screen is reset when a relay pin toggles.
+    // For now, just call init()
+    init();
+}
+
 #ifndef UINT16_MAX
 #define UINT16_MAX 65535
 #endif

--- a/src/displays/DisplayTFT_eSPI.h
+++ b/src/displays/DisplayTFT_eSPI.h
@@ -28,6 +28,7 @@ public:
     ~LcdDisplay();
     // initializes the lcd display
     void init();
+    void reset();
 
     void printAll()
     {

--- a/src/extended_async_json_handler.h
+++ b/src/extended_async_json_handler.h
@@ -10,25 +10,26 @@
  
  #if ASYNC_JSON_SUPPORT == 1
  
-/**
- * @class PutAsyncCallbackJsonWebHandler
- * @brief Extends AsyncCallbackJsonWebHandler to support custom JSON request handling for HTTP PUT.
- *
- * This class provides the ability to process incoming PUT requests in an `AsyncWebServer`
- * using a user-defined handler function. The handler processes the JSON payload and returns
- * a success or failure response based on its logic.
- */
- class PutAsyncCallbackJsonWebHandler : public AsyncCallbackJsonWebHandler {
-   protected:
+ /**
+  * @class PutAsyncCallbackJsonWebHandler
+  * @brief Extends AsyncCallbackJsonWebHandler to support custom JSON request handling for HTTP PUT.
+  *
+  * This class provides the ability to process incoming PUT requests in an `AsyncWebServer`
+  * using a user-defined handler function. The handler processes the JSON payload and returns
+  * a success or failure response based on its logic.
+  */
+ class PutAsyncCallbackJsonWebHandler : public AsyncCallbackJsonWebHandler
+ {
+ protected:
      /**
       * @brief Pointer to the custom handler function.
       *
       * The custom handler function processes the JSON payload and determines whether the
       * request should be considered successful or not.
       */
-     bool (*_customHandler)(const JsonDocument&, bool);
+     bool (*_customHandler)(const JsonDocument &, bool);
  
-   public:
+ public:
      /**
       * @brief Constructor for PutAsyncCallbackJsonWebHandler.
       *
@@ -41,94 +42,94 @@
       * the handler is not provided or fails, an appropriate HTTP response will be sent to the client.
       */
      PutAsyncCallbackJsonWebHandler(
-         const char* uri,
-         bool (*customHandler)(const JsonDocument&, bool) = nullptr)
-       : AsyncCallbackJsonWebHandler(
-             uri,
-             [customHandler](AsyncWebServerRequest* request, JsonVariant& json) {
-                 if (!customHandler) {
-                     request->send(500, "application/json", "{\"error\":\"No handler provided\"}");
-                     return;
-                 }
+         const char *uri, bool (*customHandler)(const JsonDocument &, bool) = nullptr)
+         : AsyncCallbackJsonWebHandler(
+               uri, [customHandler](AsyncWebServerRequest *request, JsonVariant &json)
+               {
+                   if (!customHandler) {
+                       request->send(500, "application/json", "{\"error\":\"No handler provided\"}");
+                       return;
+                   }
  
-                 // Parse the JSON payload
-                 JsonDocument doc;
-                 doc = json.as<JsonObject>();
+                   // Parse the JSON payload
+                   JsonDocument doc;
+                   doc = json.as<JsonObject>();
  
-                 // Call the handler
-                 if (customHandler(doc, true)) {
-                     request->send(200, "application/json", "{\"status\":\"ok\"}");
-                 } else {
-                     request->send(400, "application/json", "{\"status\":\"error\"}");
-                 }
-             }),
-         _customHandler(customHandler) {
-          setMethod(HTTP_PUT);
-         }
+                   // Call the handler
+                   if (customHandler(doc, true)) {
+                       request->send(200, "application/json", "{\"status\":\"ok\"}");
+                   } else {
+                       request->send(400, "application/json", "{\"status\":\"error\"}");
+                   }
+               }),
+           _customHandler(customHandler)
+     {
+         setMethod(HTTP_PUT);
+     }
  };
-
-
-/**
- * @class GetAsyncCallbackJsonWebHandler
- * @brief Extends AsyncCallbackJsonWebHandler to support custom JSON response handling for HTTP GET.
- *
- * This class provides the ability to process incoming GET requests in an `AsyncWebServer`
- * using a user-defined handler function that generates and returns JSON data.
- */
-class GetAsyncCallbackJsonWebHandler : public AsyncCallbackJsonWebHandler {
-  protected:
-  /**
-   * @brief Pointer to the custom handler function.
-   *
-   * The custom handler function generates JSON data to be sent in the response.
-   * It accepts a `JsonDocument` reference which it populates with the response data.
-   */
-  void (*_customHandler)(JsonDocument&);
-  
-  public:
-      /**
-       * @brief Constructor for GetAsyncCallbackJsonWebHandler.
-       *
-       * @param uri The URI to handle.
-       * @param customHandler A pointer to the custom handler function. The function must accept
-       *        a `JsonDocument` reference and populate it with the response data.
-       *
-       * The custom handler function will be invoked for each GET request to the specified URI.
-       * If the handler is not provided, an appropriate HTTP response will be sent to the client.
-       */
-      GetAsyncCallbackJsonWebHandler(
-        const char* uri,
-        void (*customHandler)(JsonDocument&) = nullptr)
-      : AsyncCallbackJsonWebHandler(
-            uri,
-            [customHandler](AsyncWebServerRequest* request, JsonVariant& json) {
-                if (!customHandler) {
-                    request->send(500, "application/json", "{\"error\":\"No handler provided\"}");
-                    return;
-                }
-
-                AsyncJsonResponse *response = new AsyncJsonResponse();
-                {
-                  JsonDocument doc;
-                  customHandler(doc);
-              
-                  // // Print the contents of doc to the serial console
-                  // Serial.println(F("Generated JSON:"));
-                  // serializeJsonPretty(doc, Serial); // Pretty print for easier reading
-                  // Serial.println(); // Add a newline for better formatting
-              
-                  response->getRoot().set(doc);
-                }
-              
-                response->setLength();
-                request->send(response);
-
-            }),
-        _customHandler(customHandler) {
-          setMethod(HTTP_GET);
-        }
-
-  };
+ 
+ /**
+  * @class GetAsyncCallbackJsonWebHandler
+  * @brief Extends AsyncCallbackJsonWebHandler to support custom JSON response handling for HTTP GET.
+  *
+  * This class provides the ability to process incoming GET requests in an `AsyncWebServer`
+  * using a user-defined handler function that generates and returns JSON data.
+  */
+ class GetAsyncCallbackJsonWebHandler : public AsyncCallbackJsonWebHandler
+ {
+ protected:
+     /**
+      * @brief Pointer to the custom handler function.
+      *
+      * The custom handler function generates JSON data to be sent in the response.
+      * It accepts a `JsonDocument` reference which it populates with the response data.
+      */
+     void (*_customHandler)(JsonDocument &);
+ 
+ public:
+     /**
+      * @brief Constructor for GetAsyncCallbackJsonWebHandler.
+      *
+      * @param uri The URI to handle.
+      * @param customHandler A pointer to the custom handler function. The function must accept
+      *        a `JsonDocument` reference and populate it with the response data.
+      *
+      * The custom handler function will be invoked for each GET request to the specified URI.
+      * If the handler is not provided, an appropriate HTTP response will be sent to the client.
+      */
+     GetAsyncCallbackJsonWebHandler(
+         const char *uri,
+         void (*customHandler)(JsonDocument &) = nullptr)
+         : AsyncCallbackJsonWebHandler(
+               uri,
+               [customHandler](AsyncWebServerRequest *request, JsonVariant &json)
+               {
+                   if (!customHandler) {
+                       request->send(500, "application/json", "{\"error\":\"No handler provided\"}");
+                       return;
+                   }
+ 
+                   AsyncJsonResponse *response = new AsyncJsonResponse();
+                   {
+                       JsonDocument doc;
+                       customHandler(doc);
+ 
+                       // // Print the contents of doc to the serial console
+                       // Serial.println(F("Generated JSON:"));
+                       // serializeJsonPretty(doc, Serial); // Pretty print for easier reading
+                       // Serial.println(); // Add a newline for better formatting
+ 
+                       response->getRoot().set(doc);
+                   }
+ 
+                   response->setLength();
+                   request->send(response);
+               }),
+           _customHandler(customHandler)
+     {
+         setMethod(HTTP_GET);
+     }
+ };
  
  #endif // ASYNC_JSON_SUPPORT == 1
  

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -200,7 +200,8 @@ bool processDeviceUpdateJson(const JsonDocument& json, bool triggerUpstreamUpdat
 // Allows us to process the device definition update in the main loop rather than in the async handler
 void httpServer::processQueuedDeviceDefinition() {
     if(device_definition_update_requested) {
-        DeviceConfig print = deviceManager.updateDeviceDefinition(dev);   // Save the device definition (if valid)
+        /*DeviceConfig print =*/
+        deviceManager.updateDeviceDefinition(dev);   // Save the device definition (if valid)
         device_definition_update_requested = false;
     }
 }
@@ -307,6 +308,17 @@ bool processExtendedSettingsJson(const JsonDocument& json, bool triggerUpstreamU
         }
     } else {
         Log.warning(F("Invalid [invertTFT]:(%s) received (wrong type).\r\n"), json[ExtendedSettingsKeys::invertTFT]);
+        failCount++;
+    }
+
+    // Reset Screen on Pin Toggle Flag
+    if(json[ExtendedSettingsKeys::resetScreenOnPin].is<bool>()) {
+        if(extendedSettings.resetScreenOnPin != json[ExtendedSettingsKeys::resetScreenOnPin].as<bool>()) {
+            extendedSettings.setResetScreenOnPin(json[ExtendedSettingsKeys::resetScreenOnPin].as<bool>());
+            saveSettings = true;
+        }
+    } else {
+        Log.warning(F("Invalid [resetScreenOnPin]:(%s) received (wrong type).\r\n"), json[ExtendedSettingsKeys::resetScreenOnPin]);
         failCount++;
     }
 

--- a/src/rest/rest_processing.cpp
+++ b/src/rest/rest_processing.cpp
@@ -247,7 +247,8 @@ void restHandler::load_devices_from_array(JsonArray &root) {
         // serializeJsonPretty(kv, Serial);  // Print the received JSON to the console
         // piLink.receiveJsonMessage(doc);                                   // Read the JSON off the line from the Pi
         dev = DeviceManager::readJsonIntoDeviceDef(kv);                  // Parse the JSON into a DeviceDefinition object
-        DeviceConfig print = deviceManager.updateDeviceDefinition(dev);   // Save the device definition (if valid)
+        /*DeviceConfig print =*/ 
+        deviceManager.updateDeviceDefinition(dev);   // Save the device definition (if valid)
         Log.verboseln("\r\nProcessed device.");
     }
 }

--- a/src/rest/rest_send.cpp
+++ b/src/rest/rest_send.cpp
@@ -186,7 +186,6 @@ bool restHandler::send_bluetooth_crash_report() {
     String payload;
     {
         JsonDocument doc;
-        const char *url;
         char guid[20];
 
         getGuid(guid);


### PR DESCRIPTION
A user on HomeBrewTalk noted that although he used a pin-based relay, he didn't experience screen blanking, and would prefer not to have the screen reinitialize and "flash". This PR adds an option in the settings to disable that behavior. 