### PR TITLE
Pre-load and initialize configured pins

### DIFF
--- a/src/DeviceManager.cpp
+++ b/src/DeviceManager.cpp
@@ -1266,6 +1266,29 @@ void DeviceManager::outputRawDeviceValue(DeviceConfig* config, void* pv, JsonDoc
 #endif
 }
 
+/**
+ * @brief Scan the filesystem for "pin" actuators, and set their pin mode early.
+ * 
+ */
+void DeviceManager::preloadActuatorPins() {
+	// Quick scan for pin-based devices to get their invert state, and set pin mode (with them defaulting to "off")
+	for (uint8_t i = 0; i < Config::EepromFormat::MAX_DEVICES; i++) {
+		DeviceConfig dev;
+		dev = eepromManager.fetchDevice(i);
+		if (dev.deviceHardware == DEVICE_HARDWARE_PIN) {
+			if (deviceType(dev.deviceFunction) == DEVICETYPE_SWITCH_ACTUATOR) {
+				digitalWrite(dev.hw.pinNr, dev.hw.invert ? HIGH : LOW); // Set output register FIRST, THEN enable as output
+				pinMode(dev.hw.pinNr, OUTPUT);
+			} else if (deviceType(dev.deviceFunction) == DEVICETYPE_SWITCH_SENSOR) {
+				pinMode(dev.hw.pinNr, INPUT);
+			} else {
+				continue; // only process pin-based actuators
+			}
+		}
+	}
+}
+
+
 
 /**
  * Determines the class of device for the given DeviceID.

--- a/src/DeviceManager.h
+++ b/src/DeviceManager.h
@@ -316,6 +316,7 @@ public:
 	}
 
 	static void setupUnconfiguredDevices();
+	static void preloadActuatorPins();
 
 	/**
 	 * \brief Determines if the given device config is complete.

--- a/src/brewpi-esp8266.cpp
+++ b/src/brewpi-esp8266.cpp
@@ -147,9 +147,7 @@ void setup()
     FILESYSTEM.begin();
   #endif
 
-  pinMode(coolingPin, OUTPUT);
-  pinMode(heatingPin, OUTPUT);
-  pinMode(doorPin, INPUT);
+  deviceManager.preloadActuatorPins();  // Preload any pin-based actuators to set their pin modes
 
   extendedSettings.loadFromFilesystem();
   upstreamSettings.loadFromFilesystem();
@@ -183,7 +181,7 @@ void setup()
 
 	logDebug("started");
 	tempControl.init();
-	settingsManager.loadSettings();
+	settingsManager.loadSettings();  // Also fully loads devices
 
 #if BREWPI_SIMULATE
 	simulator.step();


### PR DESCRIPTION
- Ensures output pins are immediately reset at reboot
- Prevents pins from being automaticallly triggered at boot